### PR TITLE
Update ckan api

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:2-alpine
 LABEL maintainer="EEA: IDM2 A-Team <eea-edw-a-team-alerts@googlegroups.com>"
 
 COPY . /
-RUN apk add --no-cache --virtual .run-deps tzdata
+RUN apk add --no-cache --virtual .run-deps tzdata git
 RUN pip install -r /app/requirements.txt
 
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/app/ckanclient.py
+++ b/app/ckanclient.py
@@ -158,7 +158,7 @@ if __name__ == '__main__':
         #query dataset data from SDS
         dataset_rdf, dataset_json, msg = cc.get_dataset_data(dataset_url, dataset_identifier)
         if not msg:
-            dump_rdf('.debug.1.sds.%s.rdf.xml' % dataset_identifier, dataset_rdf)
+            dump_rdf('.debug.1.sds.%s.rdf.xml' % dataset_identifier, dataset_rdf.decode('utf8'))
             dump_json('.debug.2.sds.%s.json.txt' % dataset_identifier, dataset_json)
 
             ckan_uri = cc.odp.get_ckan_uri(dataset_identifier)

--- a/app/ckanclient.py
+++ b/app/ckanclient.py
@@ -88,7 +88,7 @@ class CKANClient:
             dataset_rdf, dataset_json, msg = self.get_dataset_data(dataset_url, dataset_identifier)
             if dataset_rdf is not None and dataset_json is not None:
                 #connect to ODP and handle dataset action
-                msg = self.set_dataset_data(action, dataset_url, dataset_rdf, dataset_json)
+                msg = self.set_dataset_data(action, dataset_identifier, dataset_url, dataset_json)
                 if msg:
                     logger.error('ODP ERROR for \'%s\' dataset \'%s\': %s',
                                  action, dataset_url, msg)
@@ -128,12 +128,12 @@ class CKANClient:
                          dataset_url, dataset_identifier, msg)
             return None, None, msg
 
-    def set_dataset_data(self, action, dataset_url, dataset_data_rdf, dataset_json):
+    def set_dataset_data(self, action, dataset_identifier, dataset_url, dataset_json):
         """ Use data from SDS in JSON format and update the ODP [#68136]
         """
         logger.info('START setting \'%s\' dataset data - \'%s\'', action, dataset_url)
 
-        resp, msg = self.odp.call_action(action, dataset_json, dataset_data_rdf)
+        resp, msg = self.odp.call_action(action, dataset_identifier, dataset_json)
 
         if not msg:
             logger.info('DONE setting \'%s\' dataset data - \'%s\'', action, dataset_url)

--- a/app/ckanclient.py
+++ b/app/ckanclient.py
@@ -152,7 +152,7 @@ if __name__ == '__main__':
     cc = CKANClient('odp_queue')
 
     if args.debug:
-        dataset_url = 'http://www.eea.europa.eu/data-and-maps/data/european-union-emissions-trading-scheme-eu-ets-data-from-citl-8'
+        dataset_url = 'http://www.eea.europa.eu/data-and-maps/data/marine-litter'
         dataset_identifier = dataset_url.split('/')[-1]
 
         #query dataset data from SDS
@@ -161,22 +161,17 @@ if __name__ == '__main__':
             dump_rdf('.debug.1.sds.%s.rdf.xml' % dataset_identifier, dataset_rdf)
             dump_json('.debug.2.sds.%s.json.txt' % dataset_identifier, dataset_json)
 
-            #build the package structure with data from SDS
-            package_name, package_data = cc.odp.transformJSON2DataPackage(dataset_json, dataset_rdf)
-            dump_json('.debug.3.cc.%s.json.txt' % dataset_identifier, package_data)
+            ckan_uri = cc.odp.get_ckan_uri(dataset_identifier)
+            ckan_rdf = cc.odp.render_ckan_rdf(ckan_uri, dataset_json)
+            dump_rdf('.debug.3.odp.%s.rdf.xml' % dataset_identifier, ckan_rdf)
 
-            #query and retreive the ODP package data
-            package = cc.odp.package_search(prop='identifier', value=dataset_identifier)[0]
-            dump_json('.debug.4.odp.package.%s.json.txt' % dataset_identifier, package)
+            save_resp = cc.odp.package_save(ckan_uri, ckan_rdf)
+            dump_json('.debug.4.odp.%s.save.resp.json.txt' % dataset_identifier, save_resp)
 
-            #merge the ODP package with the package build from SDS data
-            package.update(package_data)
-            dump_json('.debug.5.cc.package.%s.json.txt' % dataset_identifier, package)
+            # TODO delete (currently returns http 500 internal error)
+            # delete_resp = cc.odp.package_delete(dataset_identifier)
+            # dump_json('.debug.5.odp.%s.delete.resp.json.txt' % dataset_identifier, delete_resp)
 
-            #update ODP - CAREFULLY WHEN UNCOMMENT THE FOLLOWING LINES - THE ODP DATASET GETS UPDATED!
-            package_response, msg = cc.odp.package_update(package_data)
-            if not msg:
-                dump_json('.debug.6.odp.package.%s.json.txt' % dataset_identifier, package_response)
     else:
         #read and process all messages from specified queue
         cc.start_consuming_ex()

--- a/app/ckanclient.py
+++ b/app/ckanclient.py
@@ -152,15 +152,26 @@ if __name__ == '__main__':
     cc = CKANClient('odp_queue')
 
     if args.debug:
-        #dataset_url = 'http://www.eea.europa.eu/data-and-maps/data/european-union-emissions-trading-scheme-12'
-        #dataset_url = 'http://www.eea.europa.eu/data-and-maps/data/heat-eutrophication-assessment-tool'
-        #dataset_url = 'http://www.eea.europa.eu/data-and-maps/data/fluorinated-greenhouse-gases-aggregated-data'
-        dataset_url = 'http://www.eea.europa.eu/data-and-maps/data/marine-litter'
-        dataset_identifier = dataset_url.split('/')[-1]
+        urls = [
+            'http://www.eea.europa.eu/data-and-maps/data/european-union-emissions-trading-scheme-8',
+            'http://www.eea.europa.eu/data-and-maps/data/european-union-emissions-trading-scheme-12',
+            'http://www.eea.europa.eu/data-and-maps/data/heat-eutrophication-assessment-tool',
+            'http://www.eea.europa.eu/data-and-maps/data/fluorinated-greenhouse-gases-aggregated-data',
+            'http://www.eea.europa.eu/data-and-maps/data/marine-litter',
+            'http://www.eea.europa.eu/data-and-maps/data/clc-2006-raster-4',
+            'http://www.eea.europa.eu/data-and-maps/data/vans-11',
+            'http://www.eea.europa.eu/data-and-maps/data/vans-12',
+            'http://www.eea.europa.eu/data-and-maps/data/esd-1',
+            'http://www.eea.europa.eu/data-and-maps/data/eunis-db',
+        ]
 
-        #query dataset data from SDS
-        dataset_rdf, dataset_json, msg = cc.get_dataset_data(dataset_url, dataset_identifier)
-        if not msg:
+        for dataset_url in urls:
+            dataset_identifier = dataset_url.split('/')[-1]
+
+            #query dataset data from SDS
+            dataset_rdf, dataset_json, msg = cc.get_dataset_data(dataset_url, dataset_identifier)
+            assert not msg
+
             dump_rdf('.debug.1.sds.%s.rdf.xml' % dataset_identifier, dataset_rdf.decode('utf8'))
             dump_json('.debug.2.sds.%s.json.txt' % dataset_identifier, dataset_json)
 

--- a/app/ckanclient.py
+++ b/app/ckanclient.py
@@ -153,6 +153,8 @@ if __name__ == '__main__':
 
     if args.debug:
         #dataset_url = 'http://www.eea.europa.eu/data-and-maps/data/european-union-emissions-trading-scheme-12'
+        #dataset_url = 'http://www.eea.europa.eu/data-and-maps/data/heat-eutrophication-assessment-tool'
+        #dataset_url = 'http://www.eea.europa.eu/data-and-maps/data/fluorinated-greenhouse-gases-aggregated-data'
         dataset_url = 'http://www.eea.europa.eu/data-and-maps/data/marine-litter'
         dataset_identifier = dataset_url.split('/')[-1]
 

--- a/app/ckanclient.py
+++ b/app/ckanclient.py
@@ -152,6 +152,7 @@ if __name__ == '__main__':
     cc = CKANClient('odp_queue')
 
     if args.debug:
+        #dataset_url = 'http://www.eea.europa.eu/data-and-maps/data/european-union-emissions-trading-scheme-12'
         dataset_url = 'http://www.eea.europa.eu/data-and-maps/data/marine-litter'
         dataset_identifier = dataset_url.split('/')[-1]
 

--- a/app/config.py
+++ b/app/config.py
@@ -45,8 +45,8 @@ other_config = {
 def dump_rdf(fname, value):
     """ Useful when debugging RDF results.
     """
-    f = open(fname, 'w')
-    f.write(value)
+    f = open(fname, 'wb')
+    f.write(value.encode('utf8'))
     f.close()
 
 def dump_json(fname, value):

--- a/app/config/query_dataset.sparql
+++ b/app/config/query_dataset.sparql
@@ -1,6 +1,7 @@
 PREFIX a: <http://www.eea.europa.eu/portal_types/Data#>
 PREFIX dt: <http://www.eea.europa.eu/portal_types/DataTable#>
 PREFIX org: <http://www.eea.europa.eu/portal_types/Organisation#>
+PREFIX daviz: <http://www.eea.europa.eu/portal_types/DavizVisualization#>
 PREFIX dct: <http://purl.org/dc/terms/>
 PREFIX ecodp: <http://open-data.europa.eu/ontologies/ec-odp#>
 PREFIX dcat: <http://www.w3.org/ns/dcat#>
@@ -45,7 +46,13 @@ CONSTRUCT {
  ?datafile a <http://www.w3.org/TR/vocab-dcat#Download>;
   ecodp:distributionFormat ?format;
   dct:description ?dftitle;
-  dct:modified ?dfmodified
+  dct:modified ?dfmodified.
+ ?dataset dcat:distribution ?daviz .
+ ?daviz a <http://www.w3.org/TR/vocab-dcat#Download>;
+  a daviz:DavizVisualization;
+  ecodp:distributionFormat "text/html";
+  dct:description ?daviz_title;
+  dcat:accessURL ?daviz_url .
 }
 WHERE
 {
@@ -78,7 +85,17 @@ WHERE
      FILTER (?dataset = <%s> )
     }
    }
+  }
+  OPTIONAL {
+   {
+    SELECT ?daviz ?daviz_title (str(?daviz) AS ?daviz_url)
+    WHERE {
+     ?daviz a daviz:DavizVisualization;
+      dct:title ?daviz_title;
+      daviz:dataLink "%s"@en .
+    }
    }
+  }
  }
  UNION
  {

--- a/app/odpclient.py
+++ b/app/odpclient.py
@@ -283,6 +283,8 @@ class ODPClient:
         """
         template = jinja_env.get_template('ckan_package.rdf.xml')
         (_name, context) = self.transformJSON2DataPackage(dataset_json, '')
+        for resource in context.get('resources', []):
+            resource['_uuid'] = str(uuid.uuid4())
         context.update({
             "uri": ckan_uri,
             "uuids": {

--- a/app/odpclient.py
+++ b/app/odpclient.py
@@ -329,8 +329,9 @@ class ODPClient:
             )
         context.update({
             "uri": ckan_uri,
-            "landingPage": re.sub(r'^http://', 'https://', context['url']),
+            "landing_page": re.sub(r'^http://', 'https://', context['url']),
             "uuids": {
+                "landing_page": str(uuid.uuid4()),
                 "contact": str(uuid.uuid4()),
                 "contact_address": str(uuid.uuid4()),
             }

--- a/app/odpclient.py
+++ b/app/odpclient.py
@@ -91,6 +91,13 @@ FILE_TYPES = {
 	'text/xml': 'XML',
 }
 
+DAVIZ_TYPE = 'http://www.eea.europa.eu/portal_types/DavizVisualization#DavizVisualization'
+
+DISTRIBUTION_TYPES = {
+    'download': 'http://publications.europa.eu/resource/authority/distribution-type/DOWNLOADABLE_FILE',
+    'visualization': 'http://publications.europa.eu/resource/authority/distribution-type/VISUALIZATION',
+}
+
 class ODPClient:
     """ ODP client
     """
@@ -144,11 +151,16 @@ class ODPClient:
         for data in dataset_json:
             if '@type' in data:
                 if RESOURCE_TYPE in data['@type']:
+                    if DAVIZ_TYPE in data['@type']:
+                        distribution_type = DISTRIBUTION_TYPES['visualization']
+                    else:
+                        distribution_type = DISTRIBUTION_TYPES['download']
                     resource = deepcopy(SKEL_RESOURCE)
                     resource.update({
                         u'description': data['http://purl.org/dc/terms/description'][0]['@value'],
                         u'format': data['http://open-data.europa.eu/ontologies/ec-odp#distributionFormat'][0]['@value'],
                         u'url': convert_directlink_to_view(data['http://www.w3.org/ns/dcat#accessURL'][0]['@value']),
+                        u'distribution_type': distribution_type,
                     })
                     dataset[u'resources'].append(resource)
 
@@ -246,6 +258,7 @@ class ODPClient:
                             u'description': 'NEWER VERSION',
                             u'format': 'text/html',
                             u'url': item,
+                            u'distribution_type': DISTRIBUTION_TYPES['download'],
                         })
                         dataset[u'resources'].append(resource)
 
@@ -255,6 +268,7 @@ class ODPClient:
                             u'description': 'OLDER VERSION',
                             u'format': 'text/html',
                             u'url': item,
+                            u'distribution_type': DISTRIBUTION_TYPES['download'],
                         })
                         dataset[u'resources'].append(resource)
 

--- a/app/odpclient.py
+++ b/app/odpclient.py
@@ -327,7 +327,8 @@ class ODPClient:
                 self.package_save(ckan_uri, ckan_rdf)
 
             elif action == 'delete':
-                self.package_delete(dataset_identifier)
+                # TODO the API returns internal error; uncomment when it works
+                pass # self.package_delete(dataset_identifier)
 
             else:
                 raise RuntimeError("Unknown action %r" % action)

--- a/app/odpclient.py
+++ b/app/odpclient.py
@@ -7,6 +7,7 @@ import re
 import json
 from pathlib import Path
 from copy import deepcopy
+import uuid
 
 import ckanapi
 import rdflib
@@ -281,11 +282,15 @@ class ODPClient:
         """ Render a RDF/XML that the ODP API will accept
         """
         template = jinja_env.get_template('ckan_package.rdf.xml')
-        return template.render({
+        (_name, context) = self.transformJSON2DataPackage(dataset_json, '')
+        context.update({
             "uri": ckan_uri,
-            "title": "ceva",
-            "description": "some description",
+            "uuids": {
+                "contact": str(uuid.uuid4()),
+                "contact_address": str(uuid.uuid4()),
+            }
         })
+        return template.render(context)
 
     def package_save(self, ckan_uri, ckan_rdf):
         """ Save a package

--- a/app/odpclient.py
+++ b/app/odpclient.py
@@ -329,6 +329,7 @@ class ODPClient:
             )
         context.update({
             "uri": ckan_uri,
+            "landingPage": re.sub(r'^http://', 'https://', context['url']),
             "uuids": {
                 "contact": str(uuid.uuid4()),
                 "contact_address": str(uuid.uuid4()),

--- a/app/odpclient.py
+++ b/app/odpclient.py
@@ -67,6 +67,30 @@ DATASET_EXISTS = 1
 DATASET_DELETED = 2
 DATASET_PRIVATE = 3
 
+FILE_TYPES = {
+	'application/msaccess': 'MDB',
+	'application/msword': 'DOC',
+	'application/octet-stream': 'OCTET',
+	'application/pdf': 'PDF',
+	'application/vnd.google-earth.kml+xml': 'KML',
+	'application/vnd.ms-excel': 'XLS',
+	'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': 'XLSX',
+	'application/vnd.openxmlformats-officedocument.wordprocessingml.document': 'DOCX',
+	'application/x-dbase': 'DBF',
+	'application/x-e00': 'E00',
+	'application/xml': 'XML',
+	'application/zip': 'ZIP',
+	'image/gif': 'GIF',
+	'image/jpeg': 'JPEG',
+	'image/png': 'PNG',
+	'image/tiff': 'TIFF',
+	'text/comma-separated-values': 'CSV',
+	'text/csv': 'CSV',
+	'text/html': 'HTML',
+	'text/plain': 'TXT',
+	'text/xml': 'XML',
+}
+
 class ODPClient:
     """ ODP client
     """
@@ -285,6 +309,10 @@ class ODPClient:
         (_name, context) = self.transformJSON2DataPackage(dataset_json, '')
         for resource in context.get('resources', []):
             resource['_uuid'] = str(uuid.uuid4())
+            resource['filetype'] = (
+                "http://publications.europa.eu/resource/authority/file-type/"
+                + FILE_TYPES.get(resource.get('format'), 'OCTET')
+            )
         context.update({
             "uri": ckan_uri,
             "uuids": {

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,6 +1,16 @@
 -f https://eggrepo.eea.europa.eu/simple/
-pika
-ckanapi
-rdflib
-rdflib-jsonld
+certifi==2018.8.24
+chardet==3.0.4
+ckanapi==4.1
+docopt==0.6.2
 eea.rabbitmq.client==1.5
+idna==2.7
+isodate==0.6.0
+pika==0.12.0
+pyparsing==2.2.1
+rdflib==4.2.2
+rdflib_jsonld==0.4.0
+requests==2.19.1
+simplejson==3.16.0
+six==1.11.0
+urllib3==1.23

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,11 +1,14 @@
 -f https://eggrepo.eea.europa.eu/simple/
 certifi==2018.8.24
 chardet==3.0.4
-ckanapi==4.1
+git+https://github.com/eea/ckanapi.git@cee14cdde5a79216b6cb5ad1b7298d5364dcadd8#egg=ckanapi
 docopt==0.6.2
 eea.rabbitmq.client==1.5
 idna==2.7
 isodate==0.6.0
+jinja2==2.10.3
+markupsafe==1.1.1
+pathlib==1.0.1
 pika==0.12.0
 pyparsing==2.2.1
 rdflib==4.2.2

--- a/app/sdsclient.py
+++ b/app/sdsclient.py
@@ -99,15 +99,19 @@ class SDSClient:
         """ Generic method to query SDS to be used all around.
         """
         result, msg = None, ''
-        query_url = '%(endpoint)s?%(query)s' % {'endpoint': self.endpoint, 'query': urllib.urlencode(query)}
         opener = urllib2.build_opener(urllib2.HTTPHandler)
         urllib2.install_opener(opener)
-        req = urllib2.Request(query_url)
+        data = urllib.urlencode(query)
+        req = urllib2.Request(self.endpoint, data=data)
+        req.add_header('Content-Type', 'application/x-www-form-urlencoded')
         req.add_header('Accept', content_type)
         try:
             conn = urllib2.urlopen(req, timeout=self.timeout)
         except Exception, err:
             logger.error('SDS connection error: %s', err)
+            if err.url != self.endpoint:
+                logger.error('Received redirect from SDS: %s to %s',
+                             self.endpoint, err.url)
             msg = 'Failure in open'
             conn = None
         if conn:

--- a/app/sdsclient.py
+++ b/app/sdsclient.py
@@ -144,6 +144,7 @@ class SDSClient:
                 self.foaf_workplaceHomepage,
                 self.odp_license,
                 dataset_url,
+                dataset_url,
                 dataset_url),
             'format': 'application/xml'
         }

--- a/app/sdsclient.py
+++ b/app/sdsclient.py
@@ -187,6 +187,20 @@ class SDSClient:
                 logger.info('DONE query all datasets')
         return result_json, msg
 
+    def get_rabbit(self):
+        rabbit = RabbitMQConnector(**rabbit_config)
+        rabbit.open_connection()
+        rabbit.declare_queue(self.queue_name)
+        return rabbit
+
+    def add_to_queue(self, rabbit, action, dataset_url, dataset_identifier, counter=1):
+        body = '%(action)s|%(dataset_url)s|%(dataset_identifier)s' % {
+            'action': action,
+            'dataset_url': dataset_url,
+            'dataset_identifier': dataset_identifier}
+        logger.info('BULK update %s: sending \'%s\' in \'%s\'', counter, body, self.queue_name)
+        rabbit.send_message(self.queue_name, body)
+
     def bulk_update(self):
         """ Queries SDS for all datasets and injects messages in rabbitmq.
         """
@@ -197,20 +211,13 @@ class SDSClient:
         else:
             datasets_json = result_json['results']['bindings']
             logger.info('BULK update: %s datasets found', len(datasets_json))
-            rabbit = RabbitMQConnector(**rabbit_config)
-            rabbit.open_connection()
-            rabbit.declare_queue(self.queue_name)
+            rabbit = self.get_rabbit()
             counter = 1
             for item_json in datasets_json:
                 dataset_identifier = item_json['id']['value']
                 dataset_url = item_json['dataset']['value']
                 action = 'update'
-                body = '%(action)s|%(dataset_url)s|%(dataset_identifier)s' % {
-                    'action': action,
-                    'dataset_url': dataset_url,
-                    'dataset_identifier': dataset_identifier}
-                logger.info('BULK update %s: sending \'%s\' in \'%s\'', counter, body, self.queue_name)
-                rabbit.send_message(self.queue_name, body)
+                self.add_to_queue(rabbit, action, dataset_url, dataset_identifier, counter)
                 counter += 1
             rabbit.close_connection()
         logger.info('DONE bulk update')
@@ -225,12 +232,18 @@ if __name__ == '__main__':
 
     if args.debug:
         #query dataset
-        dataset_url = 'http://www.eea.europa.eu/themes/biodiversity/document-library/natura-2000/natura-2000-network-statistics/natura-2000-barometer-statistics/statistics/barometer-statistics'
+        dataset_url = 'http://www.eea.europa.eu/data-and-maps/data/marine-litter'
         dataset_identifier = dataset_url.split('/')[-1]
-        result_rdf, result_json, msg = sds.query_dataset(dataset_url, dataset_identifier)
-        if not msg:
-            dump_rdf('.debug.1.sds.%s.rdf.xml' % dataset_identifier, result_rdf)
-            dump_json('.debug.2.sds.%s.json.txt' % dataset_identifier, result_json)
+        # result_rdf, result_json, msg = sds.query_dataset(dataset_url, dataset_identifier)
+        # if not msg:
+        #     dump_rdf('.debug.1.sds.%s.rdf.xml' % dataset_identifier, result_rdf)
+        #     dump_json('.debug.2.sds.%s.json.txt' % dataset_identifier, result_json)
+
+        # add to queue
+        _rabbit = sds.get_rabbit()
+        sds.add_to_queue(_rabbit, 'update', dataset_url, dataset_identifier)
+        sds.add_to_queue(_rabbit, 'delete', dataset_url, dataset_identifier)
+        _rabbit.close_connection()
 
         #query all datasets - UNCOMMENT IF YOU NEED THIS
         #result_json, msg = sds.query_all_datasets()

--- a/app/templates/ckan_package.rdf.xml
+++ b/app/templates/ckan_package.rdf.xml
@@ -6,6 +6,7 @@
    xmlns:dcterms="http://purl.org/dc/terms/"
    xmlns:foaf="http://xmlns.com/foaf/0.1/"
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:schema="http://schema.org/"
    xmlns:vcard="http://www.w3.org/2006/vcard/ns#"
 >
 
@@ -18,7 +19,7 @@
     <dcterms:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">{{ issued }}</dcterms:issued>
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">{{ metadata_modified }}</dcterms:modified>
     <dcat:contactPoint rdf:resource="http://www.w3.org/2006/vcard/ns#Kind/{{ uuids.contact }}"/>
-    <dcat:landingPage>{{ landingPage }}</dcat:landingPage>
+    <dcat:landingPage rdf:resource="http://data.europa.eu/88u/document/{{ uuids.landing_page }}" />
 
     {%- for tag in tags %}
     <dcat:keyword>{{ tag.name }}</dcat:keyword>
@@ -41,6 +42,14 @@
     <adms:status rdf:resource="http://publications.europa.eu/resource/authority/dataset-status/COMPLETED"/>
   </rdf:Description>
   {%- endfor %}
+
+  <rdf:Description rdf:about="http://data.europa.eu/88u/document/{{ uuids.landing_page }}">
+    <dcterms:type rdf:resource="default_type_dcterms"/>
+    <schema:url>{{ landing_page }}</schema:url>
+    <rdf:type rdf:resource="http://xmlns.com/foaf/0.1/Document"/>
+    <foaf:topic rdf:resource="{{ uri }}"/>
+    <dcterms:title xml:lang="en">{{ title }}</dcterms:title>
+  </rdf:Description>
 
   <rdf:Description rdf:about="http://www.w3.org/2006/vcard/ns#Kind/{{ uuids.contact }}">
     <rdf:type rdf:resource="http://www.w3.org/2006/vcard/ns#Kind"/>

--- a/app/templates/ckan_package.rdf.xml
+++ b/app/templates/ckan_package.rdf.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rdf:RDF
+   xmlns:adms="http://www.w3.org/ns/adms#"
    xmlns:dcat="http://www.w3.org/ns/dcat#"
    xmlns:dcatapop="http://data.europa.eu/88u/ontology/dcatapop#"
    xmlns:dcterms="http://purl.org/dc/terms/"
@@ -12,12 +13,33 @@
     <dcterms:title xml:lang="en">{{ title }}</dcterms:title>
     <dcat:theme rdf:resource="http://publications.europa.eu/resource/authority/data-theme/ENER"/>
     <dcterms:description xml:lang="en">{{ description }}</dcterms:description>
-    <dcterms:publisher rdf:resource="http://publications.europa.eu/resource/authority/corporate-body/EEA"/>
+    <dcterms:publisher rdf:resource="{{ publisher }}"/>
     <dcterms:identifier>{{ identifier }}</dcterms:identifier>
     <dcterms:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">{{ issued }}</dcterms:issued>
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">{{ metadata_modified }}</dcterms:modified>
     <dcat:contactPoint rdf:resource="http://www.w3.org/2006/vcard/ns#Kind/{{ uuids.contact }}"/>
+
+    {%- for tag in tags %}
+    <dcat:keyword>{{ tag.name }}</dcat:keyword>
+    {%- endfor %}
+
+    {%- for resource in resources %}
+    <dcat:distribution rdf:resource="http://data.europa.eu/88u/distribution/{{ resource._uuid }}"/>
+    {%- endfor %}
   </rdf:Description>
+
+  {%- for resource in resources %}
+
+  <rdf:Description rdf:about="http://data.europa.eu/88u/distribution/{{ resource._uuid }}">
+    <rdf:type rdf:resource="http://www.w3.org/ns/dcat#Distribution" />
+    <dcterms:title xml:lang="en">{{ resource.description }}</dcterms:title>
+    <dcterms:format rdf:resource="http://publications.europa.eu/resource/authority/file-type/OCTET" />
+    <dcterms:type rdf:resource="http://publications.europa.eu/resource/authority/distribution-type/DOWNLOADABLE_FILE" />
+    <dcat:accessURL rdf:resource="{{ resource.url }}" />
+    <dcterms:license rdf:resource="http://publications.europa.eu/resource/authority/licence/CC_BY" />
+    <adms:status rdf:resource="http://publications.europa.eu/resource/authority/dataset-status/COMPLETED"/>
+  </rdf:Description>
+  {%- endfor %}
 
   <rdf:Description rdf:about="http://www.w3.org/2006/vcard/ns#Kind/{{ uuids.contact }}">
     <rdf:type rdf:resource="http://www.w3.org/2006/vcard/ns#Kind"/>

--- a/app/templates/ckan_package.rdf.xml
+++ b/app/templates/ckan_package.rdf.xml
@@ -33,7 +33,7 @@
   <rdf:Description rdf:about="http://data.europa.eu/88u/distribution/{{ resource._uuid }}">
     <rdf:type rdf:resource="http://www.w3.org/ns/dcat#Distribution" />
     <dcterms:title xml:lang="en">{{ resource.description }}</dcterms:title>
-    <dcterms:format rdf:resource="http://publications.europa.eu/resource/authority/file-type/OCTET" />
+    <dcterms:format rdf:resource="{{ resource.filetype }}" />
     <dcterms:type rdf:resource="http://publications.europa.eu/resource/authority/distribution-type/DOWNLOADABLE_FILE" />
     <dcat:accessURL rdf:resource="{{ resource.url }}" />
     <dcterms:license rdf:resource="http://publications.europa.eu/resource/authority/licence/CC_BY" />

--- a/app/templates/ckan_package.rdf.xml
+++ b/app/templates/ckan_package.rdf.xml
@@ -38,7 +38,7 @@
     <dcterms:format rdf:resource="{{ resource.filetype }}" />
     <dcterms:type rdf:resource="{{ resource.distribution_type }}" />
     <dcat:accessURL rdf:resource="{{ resource.url }}" />
-    <dcterms:license rdf:resource="http://publications.europa.eu/resource/authority/licence/CC_BY" />
+    <dcterms:license rdf:resource="http://publications.europa.eu/resource/authority/licence/CC_BY_4_0" />
     <adms:status rdf:resource="http://publications.europa.eu/resource/authority/dataset-status/COMPLETED"/>
   </rdf:Description>
   {%- endfor %}

--- a/app/templates/ckan_package.rdf.xml
+++ b/app/templates/ckan_package.rdf.xml
@@ -34,7 +34,7 @@
     <rdf:type rdf:resource="http://www.w3.org/ns/dcat#Distribution" />
     <dcterms:title xml:lang="en">{{ resource.description }}</dcterms:title>
     <dcterms:format rdf:resource="{{ resource.filetype }}" />
-    <dcterms:type rdf:resource="http://publications.europa.eu/resource/authority/distribution-type/DOWNLOADABLE_FILE" />
+    <dcterms:type rdf:resource="{{ resource.distribution_type }}" />
     <dcat:accessURL rdf:resource="{{ resource.url }}" />
     <dcterms:license rdf:resource="http://publications.europa.eu/resource/authority/licence/CC_BY" />
     <adms:status rdf:resource="http://publications.europa.eu/resource/authority/dataset-status/COMPLETED"/>

--- a/app/templates/ckan_package.rdf.xml
+++ b/app/templates/ckan_package.rdf.xml
@@ -18,6 +18,7 @@
     <dcterms:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">{{ issued }}</dcterms:issued>
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">{{ metadata_modified }}</dcterms:modified>
     <dcat:contactPoint rdf:resource="http://www.w3.org/2006/vcard/ns#Kind/{{ uuids.contact }}"/>
+    <dcat:landingPage>{{ landingPage }}</dcat:landingPage>
 
     {%- for tag in tags %}
     <dcat:keyword>{{ tag.name }}</dcat:keyword>

--- a/app/templates/ckan_package.rdf.xml
+++ b/app/templates/ckan_package.rdf.xml
@@ -5,12 +5,29 @@
    xmlns:dcterms="http://purl.org/dc/terms/"
    xmlns:foaf="http://xmlns.com/foaf/0.1/"
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:vcard="http://www.w3.org/2006/vcard/ns#"
 >
+
   <rdf:Description rdf:about="{{ uri }}">
     <dcterms:title xml:lang="en">{{ title }}</dcterms:title>
     <dcat:theme rdf:resource="http://publications.europa.eu/resource/authority/data-theme/ENER"/>
     <dcterms:description xml:lang="en">{{ description }}</dcterms:description>
     <dcterms:publisher rdf:resource="http://publications.europa.eu/resource/authority/corporate-body/EEA"/>
-    </rdf:Description>
-</rdf:RDF>
+    <dcterms:identifier>{{ identifier }}</dcterms:identifier>
+    <dcterms:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">{{ issued }}</dcterms:issued>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">{{ metadata_modified }}</dcterms:modified>
+    <dcat:contactPoint rdf:resource="http://www.w3.org/2006/vcard/ns#Kind/{{ uuids.contact }}"/>
+  </rdf:Description>
 
+  <rdf:Description rdf:about="http://www.w3.org/2006/vcard/ns#Kind/{{ uuids.contact }}">
+    <rdf:type rdf:resource="http://www.w3.org/2006/vcard/ns#Kind"/>
+    <vcard:hasAddress rdf:resource="http://www.w3.org/2006/vcard/ns#Address/{{ uuids.contact_address }}"/>
+    <vcard:organisation-name>{{ contact_name }}</vcard:organisation-name>
+  </rdf:Description>
+
+  <rdf:Description rdf:about="http://www.w3.org/2006/vcard/ns#Address/{{ uuids.contact_address }}">
+    <rdf:type rdf:resource="http://www.w3.org/2006/vcard/ns#Address"/>
+    <vcard:street-address>{{ contact_address }}</vcard:street-address>
+  </rdf:Description>
+
+</rdf:RDF>

--- a/app/templates/ckan_package.rdf.xml
+++ b/app/templates/ckan_package.rdf.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF
+   xmlns:dcat="http://www.w3.org/ns/dcat#"
+   xmlns:dcatapop="http://data.europa.eu/88u/ontology/dcatapop#"
+   xmlns:dcterms="http://purl.org/dc/terms/"
+   xmlns:foaf="http://xmlns.com/foaf/0.1/"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+>
+  <rdf:Description rdf:about="{{ uri }}">
+    <dcterms:title xml:lang="en">{{ title }}</dcterms:title>
+    <dcat:theme rdf:resource="http://publications.europa.eu/resource/authority/data-theme/ENER"/>
+    <dcterms:description xml:lang="en">{{ description }}</dcterms:description>
+    <dcterms:publisher rdf:resource="http://publications.europa.eu/resource/authority/corporate-body/EEA"/>
+    </rdf:Description>
+</rdf:RDF>
+

--- a/app/templates/ckan_package.rdf.xml
+++ b/app/templates/ckan_package.rdf.xml
@@ -11,7 +11,7 @@
 
   <rdf:Description rdf:about="{{ uri }}">
     <dcterms:title xml:lang="en">{{ title }}</dcterms:title>
-    <dcat:theme rdf:resource="http://publications.europa.eu/resource/authority/data-theme/ENER"/>
+    <dcat:theme rdf:resource="http://publications.europa.eu/resource/authority/data-theme/ENVI"/>
     <dcterms:description xml:lang="en">{{ description }}</dcterms:description>
     <dcterms:publisher rdf:resource="{{ publisher }}"/>
     <dcterms:identifier>{{ identifier }}</dcterms:identifier>


### PR DESCRIPTION
Use the new CKAN API as validated in https://taskman.eionet.europa.eu/issues/103799#note-9

Notes:
* `package_delete` on the server returns a 500 internal error, need to check with maintainers
* The code currently sends a dummy RDF document. It needs to be filled out with the correct tags (https://taskman.eionet.europa.eu/issues/104029)
* Currently using the ckanapi fork (https://github.com/eea/ckanapi). Perhaps we should simply use the requests library, the server seems to implement its own API which is not really CKAN any more.
