### PR TITLE
Add aditional visualization types

### DIFF
--- a/app/ckanclient.py
+++ b/app/ckanclient.py
@@ -164,6 +164,7 @@ if __name__ == "__main__":
     if args.debug:
         _prefix = "http://www.eea.europa.eu/data-and-maps/data/"
         urls = [
+            # _prefix + "greenhouse-gas-emission-projections-for-6",
             # _prefix + "european-union-emissions-trading-scheme-8",
             _prefix + "european-union-emissions-trading-scheme-13",
             # _prefix + "heat-eutrophication-assessment-tool",

--- a/app/ckanclient.py
+++ b/app/ckanclient.py
@@ -164,11 +164,12 @@ if __name__ == "__main__":
     if args.debug:
         _prefix = "http://www.eea.europa.eu/data-and-maps/data/"
         urls = [
-            # _prefix + "greenhouse-gas-emission-projections-for-6",
+            _prefix + "fuel-quality-directive-1"
+            #_prefix + "greenhouse-gas-emission-projections-for-6",
             # _prefix + "european-union-emissions-trading-scheme-8",
-            _prefix + "european-union-emissions-trading-scheme-13",
+            #_prefix + "european-union-emissions-trading-scheme-13",
             # _prefix + "heat-eutrophication-assessment-tool",
-            _prefix + "fluorinated-greenhouse-gases-aggregated-data-1",
+            #_prefix + "fluorinated-greenhouse-gases-aggregated-data-1",
             # _prefix + "marine-litter",
             # _prefix + "clc-2006-raster-4",
             # _prefix + "vans-11",

--- a/app/config/query_dataset.sparql
+++ b/app/config/query_dataset.sparql
@@ -2,6 +2,8 @@ PREFIX a: <http://www.eea.europa.eu/portal_types/Data#>
 PREFIX dt: <http://www.eea.europa.eu/portal_types/DataTable#>
 PREFIX org: <http://www.eea.europa.eu/portal_types/Organisation#>
 PREFIX daviz: <http://www.eea.europa.eu/portal_types/DavizVisualization#>
+PREFIX gis: <http://www.eea.europa.eu/portal_types/GIS%%20Application#>
+PREFIX eeafigure: <http://www.eea.europa.eu/portal_types/EEAFigure#>
 PREFIX dct: <http://purl.org/dc/terms/>
 PREFIX ecodp: <http://open-data.europa.eu/ontologies/ec-odp#>
 PREFIX dcat: <http://www.w3.org/ns/dcat#>
@@ -40,11 +42,11 @@ CONSTRUCT {
   ecodp:distributionFormat ?format;
   dct:title ?dftitle;
   dct:modified ?dfmodified.
- ?dataset dcat:distribution ?daviz .
- ?daviz a daviz:DavizVisualization;
+ ?dataset dcat:distribution ?related_item .
+ ?related_item a ?related_item_type;
   ecodp:distributionFormat "text/html";
-  dct:title ?daviz_title;
-  dcat:accessURL ?daviz_url .
+  dct:title ?related_item_title;
+  dcat:accessURL ?related_item_url .
 }
 WHERE
 {
@@ -147,15 +149,16 @@ WHERE
  }
  UNION
  {
-  ?dataset a:relatedItems ?daviz .
+  ?dataset a:relatedItems ?related_item .
   {
-   SELECT DISTINCT ?daviz ?daviz_title (str(?daviz) as ?daviz_url)
+   SELECT DISTINCT ?related_item ?related_item_title (str(?related_item) as ?related_item_url)
    WHERE
    {
-    ?daviz a daviz:DavizVisualization ;
-     dct:title ?daviz_title ;
-     dct:expires ?daviz_expires .
-    FILTER(str(?daviz_expires) = "None")
+    ?related_item a ?related_item_type;
+        dct:title ?related_item_title ;
+        dct:expires ?related_item_expires .
+    FILTER(?related_item_type IN (daviz:DavizVisualisation, eeafigure:EEAFigureFile, gis:GISApplication))
+    FILTER(str(?related_item_expires) = "None")
    }
   }
  }

--- a/app/config/query_dataset.sparql
+++ b/app/config/query_dataset.sparql
@@ -4,6 +4,8 @@ PREFIX org: <http://www.eea.europa.eu/portal_types/Organisation#>
 PREFIX daviz: <http://www.eea.europa.eu/portal_types/DavizVisualization#>
 PREFIX gis: <http://www.eea.europa.eu/portal_types/GIS%%20Application#>
 PREFIX eeafigure: <http://www.eea.europa.eu/portal_types/EEAFigure#>
+PREFIX dashboard: <http://www.eea.europa.eu/portal_types/Dashboard#>
+PREFIX infographic: <http://www.eea.europa.eu/portal_types/Infographic#>
 PREFIX dct: <http://purl.org/dc/terms/>
 PREFIX ecodp: <http://open-data.europa.eu/ontologies/ec-odp#>
 PREFIX dcat: <http://www.w3.org/ns/dcat#>
@@ -47,6 +49,11 @@ CONSTRUCT {
   ecodp:distributionFormat "text/html";
   dct:title ?related_item_title;
   dcat:accessURL ?related_item_url .
+ ?dataset dcat:distribution ?backward_related_item .
+ ?backward_related_item a ?backward_related_item_type;
+  ecodp:distributionFormat "text/html";
+  dct:title ?backward_related_item_title;
+  dcat:accessURL ?backward_related_item_url .
 }
 WHERE
 {
@@ -151,16 +158,48 @@ WHERE
  {
   ?dataset a:relatedItems ?related_item .
   {
-   SELECT DISTINCT ?related_item ?related_item_title (str(?related_item) as ?related_item_url)
+   SELECT DISTINCT ?related_item ?related_item_title (str(?related_item) as ?related_item_url) ?related_item_type
    WHERE
    {
     ?related_item a ?related_item_type;
         dct:title ?related_item_title ;
         dct:expires ?related_item_expires .
-    FILTER(?related_item_type IN (daviz:DavizVisualisation, eeafigure:EEAFigureFile, gis:GISApplication))
     FILTER(str(?related_item_expires) = "None")
+    FILTER(?related_item_type IN (
+        daviz:DavizVisualisation,
+        eeafigure:EEAFigure,
+        gis:GISApplication
+    ))
    }
   }
+ }
+ UNION
+ {
+  ?backward_related_item ?backward_property ?dataset .
+  {
+   SELECT DISTINCT ?backward_related_item ?backward_related_item_title (str(?backward_related_item) as ?backward_related_item_url) ?backward_related_item_type
+   WHERE
+   {
+    ?backward_related_item a ?backward_related_item_type;
+        dct:title ?backward_related_item_title ;
+        dct:expires ?backward_related_item_expires .
+    FILTER(str(?backward_related_item_expires) = "None")
+    FILTER(?backward_related_item_type IN (
+        daviz:DavizVisualisation,
+        eeafigure:EEAFigure,
+        gis:GISApplication,
+        dashboard:Dashboard,
+        infographic:Infographic
+    ))
+   }
+  }
+  FILTER(?backward_property IN (
+    daviz:relatedItems,
+    eeafigure:relatedItems,
+    gis:relatedItems,
+    dashboard:relatedItems,
+    infographic:relatedItems
+  ))
  }
  UNION
  {

--- a/app/config/query_dataset.sparql
+++ b/app/config/query_dataset.sparql
@@ -185,18 +185,14 @@ WHERE
         dct:expires ?backward_related_item_expires .
     FILTER(str(?backward_related_item_expires) = "None")
     FILTER(?backward_related_item_type IN (
-        daviz:DavizVisualization,
         eeafigure:EEAFigure,
-        gis:GISApplication,
         dashboard:Dashboard,
         infographic:Infographic
     ))
    }
   }
   FILTER(?backward_property IN (
-    daviz:relatedItems,
     eeafigure:relatedItems,
-    gis:relatedItems,
     dashboard:relatedItems,
     infographic:relatedItems
   ))

--- a/app/config/query_dataset.sparql
+++ b/app/config/query_dataset.sparql
@@ -166,7 +166,7 @@ WHERE
         dct:expires ?related_item_expires .
     FILTER(str(?related_item_expires) = "None")
     FILTER(?related_item_type IN (
-        daviz:DavizVisualisation,
+        daviz:DavizVisualization,
         eeafigure:EEAFigure,
         gis:GISApplication
     ))
@@ -185,7 +185,7 @@ WHERE
         dct:expires ?backward_related_item_expires .
     FILTER(str(?backward_related_item_expires) = "None")
     FILTER(?backward_related_item_type IN (
-        daviz:DavizVisualisation,
+        daviz:DavizVisualization,
         eeafigure:EEAFigure,
         gis:GISApplication,
         dashboard:Dashboard,

--- a/app/sdsclient.py
+++ b/app/sdsclient.py
@@ -36,6 +36,8 @@ EU_COUNTRY = Namespace(
 EUROVOC = Namespace("http://eurovoc.europa.eu/")
 ECODP = Namespace("http://open-data.europa.eu/ontologies/ec-odp#")
 DAVIZ = Namespace("http://www.eea.europa.eu/portal_types/DavizVisualization#")
+GIS = Namespace("http://www.eea.europa.eu/portal_types/GIS%%20Application#")
+EEAFIGURE = Namespace("http://www.eea.europa.eu/portal_types/EEAFigure#")
 
 
 FILE_TYPES = {
@@ -211,7 +213,9 @@ class SDSClient:
         for res in g.objects(dataset, DCAT.distribution):
             types = list(g.objects(res, RDF.type))
 
-            if DAVIZ.DavizVisualization in types:
+            if DAVIZ.DavizVisualization in types or\
+                    GIS.GisApplication in types or\
+                    EEAFIGURE.EEAFigureFile in types:
                 distribution_type = EU_DISTRIBUTION_TYPE.VISUALIZATION
 
             elif URIRef("http://www.w3.org/TR/vocab-dcat#Download") in types:

--- a/app/sdsclient.py
+++ b/app/sdsclient.py
@@ -38,6 +38,8 @@ ECODP = Namespace("http://open-data.europa.eu/ontologies/ec-odp#")
 DAVIZ = Namespace("http://www.eea.europa.eu/portal_types/DavizVisualization#")
 GIS = Namespace("http://www.eea.europa.eu/portal_types/GIS%%20Application#")
 EEAFIGURE = Namespace("http://www.eea.europa.eu/portal_types/EEAFigure#")
+DASHBOARD = Namespace("http://www.eea.europa.eu/portal_types/Dashboard#")
+INFOGRAPHIC = Namespace("http://www.eea.europa.eu/portal_types/Infographic#")
 
 
 FILE_TYPES = {
@@ -210,12 +212,12 @@ class SDSClient:
 
         resources = []
 
+        visualisation_types = [DAVIZ.DavizVisualization, GIS.GisApplication, EEAFIGURE.EEAFigure,
+                               INFOGRAPHIC.Infographic, DASHBOARD.Dashboard]
         for res in g.objects(dataset, DCAT.distribution):
             types = list(g.objects(res, RDF.type))
 
-            if DAVIZ.DavizVisualization in types or\
-                    GIS.GisApplication in types or\
-                    EEAFIGURE.EEAFigureFile in types:
+            if any([True if visual_type in types else False for visual_type in visualisation_types]):
                 distribution_type = EU_DISTRIBUTION_TYPE.VISUALIZATION
 
             elif URIRef("http://www.w3.org/TR/vocab-dcat#Download") in types:

--- a/app/tests/sds_responses/DAT-137-en.rdf
+++ b/app/tests/sds_responses/DAT-137-en.rdf
@@ -1,0 +1,322 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF
+	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/eunis-habitat-classification/eunis-habitat-classification-review-2017/eunis-habitat-classification-2017-revised">
+	<title xmlns="http://purl.org/dc/terms/" xml:lang="en">EUNIS habitat classification 2017 (Revised forest heathland scrub tundra)</title>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/eunis-habitat-classification">
+	<distribution xmlns="http://www.w3.org/ns/dcat#" rdf:resource="http://www.eea.europa.eu/data-and-maps/data/eunis-habitat-classification/habitats/eunis-habitats-complete-with-descriptions.xls"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/eunis-habitat-classification/documentation/eunis-habitat-classification-users-guide-v2.pdf">
+	<rdf:type rdf:resource="http://www.w3.org/TR/vocab-dcat#Download"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/figures/eunis-habitats-based-on-corine-land-cover">
+	<distributionFormat xmlns="http://open-data.europa.eu/ontologies/ec-odp#">text/html</distributionFormat>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/eunis-habitat-classification">
+	<description xmlns="http://purl.org/dc/terms/" xml:lang="en">The EUNIS habitat classification is a comprehensive pan-European system for habitat identification. The classification is hierarchical and covers all types of habitats from natural to artificial, from terrestrial to freshwater and marine. The habitat types are identified by specific codes, names and descriptions.</description>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/eunis-habitat-classification/documentation/eunis-2004-report.pdf">
+	<modified xmlns="http://purl.org/dc/terms/" rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-05-22T14:36:48Z</modified>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/eunis-habitat-classification/documentation/eunis-clc.pdf">
+	<distributionFormat xmlns="http://open-data.europa.eu/ontologies/ec-odp#">application/pdf</distributionFormat>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/eunis-habitat-classification/documentation/eunis-habitat-classification-users-guide-v2.pdf">
+	<accessURL xmlns="http://www.w3.org/ns/dcat#" rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.eea.europa.eu/data-and-maps/data/eunis-habitat-classification/documentation/eunis-habitat-classification-users-guide-v2.pdf/at_download/file</accessURL>
+	<modified xmlns="http://purl.org/dc/terms/" rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2014-05-26T12:16:09Z</modified>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/eunis-habitat-classification/documentation/eunis-2004-list.pdf">
+	<distributionFormat xmlns="http://open-data.europa.eu/ontologies/ec-odp#">application/pdf</distributionFormat>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/eunis-habitat-classification/habitats/eunis-habitats-complete-with-descriptions.xls">
+	<accessURL xmlns="http://www.w3.org/ns/dcat#" rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.eea.europa.eu/data-and-maps/data/eunis-habitat-classification/habitats/eunis-habitats-complete-with-descriptions.xls/at_download/file</accessURL>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/eunis-habitat-classification">
+	<subject xmlns="http://purl.org/dc/terms/">eunis habitat classification</subject>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/eunis-habitat-classification/documentation/eunis-habitat-classification-users-guide-v2.pdf">
+	<distributionFormat xmlns="http://open-data.europa.eu/ontologies/ec-odp#">application/pdf</distributionFormat>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/eunis-habitat-classification/documentation/eunis-clc.pdf">
+	<rdf:type rdf:resource="http://www.w3.org/TR/vocab-dcat#Download"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/eunis-habitat-classification/documentation/eunis-2004-report.pdf">
+	<accessURL xmlns="http://www.w3.org/ns/dcat#" rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.eea.europa.eu/data-and-maps/data/eunis-habitat-classification/documentation/eunis-2004-report.pdf/at_download/file</accessURL>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/eunis-habitat-classification/documentation/eunis-2004-list.pdf">
+	<rdf:type rdf:resource="http://www.w3.org/TR/vocab-dcat#Download"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/eunis-habitat-classification">
+	<subject xmlns="http://purl.org/dc/terms/">marine</subject>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/eunis-habitat-classification/documentation/link-between-eunis-2007-and.xls">
+	<accessURL xmlns="http://www.w3.org/ns/dcat#" rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.eea.europa.eu/data-and-maps/data/eunis-habitat-classification/documentation/link-between-eunis-2007-and.xls/at_download/file</accessURL>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/figures/eunis-habitat-types-per-biogeographic-region">
+	<rdf:type rdf:resource="http://www.eea.europa.eu/portal_types/EEAFigure#EEAFigure"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/eunis-habitat-classification/documentation/link-eunis-and-palhab2001.xls">
+	<title xmlns="http://purl.org/dc/terms/" xml:lang="en">Crosswalk EUNIS 2007 and PALHAB 2001</title>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/eunis-habitat-classification/habitats/eunis-habitats-complete-with-descriptions.xls">
+	<title xmlns="http://purl.org/dc/terms/" xml:lang="en">EUNIS habitat classification 2007 (Revised descriptions 2012) amended 2019</title>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/eunis-habitat-classification/documentation/eunis-2004-report.pdf">
+	<title xmlns="http://purl.org/dc/terms/" xml:lang="en">EUNIS habitat classification report (2004)</title>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/figures/eunis-habitats-based-on-corine-land-cover">
+	<rdf:type rdf:resource="http://www.eea.europa.eu/portal_types/EEAFigure#EEAFigure"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/eunis-habitat-classification/documentation/eunis-2004-report.pdf">
+	<distributionFormat xmlns="http://open-data.europa.eu/ontologies/ec-odp#">application/pdf</distributionFormat>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/eunis-habitat-classification/documentation/eunis-clc.pdf">
+	<accessURL xmlns="http://www.w3.org/ns/dcat#" rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.eea.europa.eu/data-and-maps/data/eunis-habitat-classification/documentation/eunis-clc.pdf/at_download/file</accessURL>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/figures/eunis-habitats-based-on-corine-land-cover">
+	<title xmlns="http://purl.org/dc/terms/" xml:lang="en">EUNIS habitats based on Corine land cover</title>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/eunis-habitat-classification/documentation/eunis-clc.pdf">
+	<title xmlns="http://purl.org/dc/terms/" xml:lang="en">Crosswalk between EUNIS habitats classification and Corine land cover</title>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/themes/biodiversity/an-introduction-to-habitats/underpinning-european-policy-on-nature-conservation-1/vegetation-eunis-habitat-suitability-map">
+	<title xmlns="http://purl.org/dc/terms/" xml:lang="en">Example of EUNIS habitat suitability map</title>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/eunis-habitat-classification/documentation/eunis-2004-list.pdf">
+	<accessURL xmlns="http://www.w3.org/ns/dcat#" rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.eea.europa.eu/data-and-maps/data/eunis-habitat-classification/documentation/eunis-2004-list.pdf/at_download/file</accessURL>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/themes/biodiversity/an-introduction-to-habitats/underpinning-european-policy-on-nature-conservation-1/vegetation-eunis-habitat-suitability-map">
+	<rdf:type rdf:resource="http://www.eea.europa.eu/portal_types/EEAFigure#EEAFigure"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/figures/eunis-habitat-types-per-biogeographic-region">
+	<title xmlns="http://purl.org/dc/terms/" xml:lang="en">EUNIS habitat types per biogeographic region</title>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/eunis-habitat-classification">
+	<subject xmlns="http://purl.org/dc/terms/">eunis</subject>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/eunis-habitat-classification/documentation/link-eunis-and-palhab2001.xls">
+	<distributionFormat xmlns="http://open-data.europa.eu/ontologies/ec-odp#">application/vnd.ms-excel</distributionFormat>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/eunis-habitat-classification">
+	<keyword xmlns="http://open-data.europa.eu/ontologies/ec-odp#">habitats</keyword>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/eunis-habitat-classification/documentation/link-between-eunis-2007-and.xls">
+	<distributionFormat xmlns="http://open-data.europa.eu/ontologies/ec-odp#">application/vnd.ms-excel</distributionFormat>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/eunis-habitat-classification/habitats/eunis-habitats-complete-with-descriptions.xls">
+	<modified xmlns="http://purl.org/dc/terms/" rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-09-13T09:18:05Z</modified>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/eunis-habitat-classification">
+	<keyword xmlns="http://open-data.europa.eu/ontologies/ec-odp#">eunis</keyword>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/eunis-habitat-classification/documentation/link-between-eunis-2007-and.xls">
+	<modified xmlns="http://purl.org/dc/terms/" rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2014-10-01T09:01:54Z</modified>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/eunis-habitat-classification/documentation/eunis-habitat-classification-users-guide-v2.pdf">
+	<title xmlns="http://purl.org/dc/terms/" xml:lang="en">EUNIS habitat classification users guide v2</title>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/eunis-habitat-classification">
+	<subject xmlns="http://purl.org/dc/terms/">vegetation</subject>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/eunis-habitat-classification/documentation/link-eunis-and-palhab2001.xls">
+	<rdf:type rdf:resource="http://www.w3.org/TR/vocab-dcat#Download"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/eunis-habitat-classification">
+	<issued xmlns="http://purl.org/dc/terms/" rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-02-09T00:00:00Z</issued>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/eunis-habitat-classification/documentation/link-between-eunis-2007-and.xls">
+	<rdf:type rdf:resource="http://www.w3.org/TR/vocab-dcat#Download"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/themes/biodiversity/an-introduction-to-habitats/underpinning-european-policy-on-nature-conservation-1/vegetation-eunis-habitat-suitability-map">
+	<accessURL xmlns="http://www.w3.org/ns/dcat#">http://www.eea.europa.eu/themes/biodiversity/an-introduction-to-habitats/underpinning-european-policy-on-nature-conservation-1/vegetation-eunis-habitat-suitability-map</accessURL>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/eunis-habitat-classification">
+	<distribution xmlns="http://www.w3.org/ns/dcat#" rdf:resource="http://www.eea.europa.eu/themes/biodiversity/an-introduction-to-habitats/underpinning-european-policy-on-nature-conservation-1/vegetation-eunis-habitat-suitability-map"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/eunis-habitat-classification/eunis-habitat-classification-review-2017/eunis-habitat-classification-2017-revised">
+	<modified xmlns="http://purl.org/dc/terms/" rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-02-09T12:57:43Z</modified>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/eunis-habitat-classification/eunis-marine-habitat-classification-review-2019/eunis-marine-habitat-classification-2019">
+	<distributionFormat xmlns="http://open-data.europa.eu/ontologies/ec-odp#">application/vnd.openxmlformats-officedocument.spreadsheetml.sheet</distributionFormat>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/eunis-habitat-classification">
+	<subject xmlns="http://purl.org/dc/terms/">terrestrial</subject>
+	<title xmlns="http://purl.org/dc/terms/" xml:lang="en">EUNIS habitat classification</title>
+	<distribution xmlns="http://www.w3.org/ns/dcat#" rdf:resource="http://www.eea.europa.eu/data-and-maps/figures/eunis-habitat-types-per-biogeographic-region"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/eunis-habitat-classification/habitats/eunis-habitats-complete-with-descriptions.xls">
+	<rdf:type rdf:resource="http://www.w3.org/TR/vocab-dcat#Download"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/eunis-habitat-classification">
+	<distribution xmlns="http://www.w3.org/ns/dcat#" rdf:resource="http://www.eea.europa.eu/data-and-maps/figures/eunis-habitats-based-on-corine-land-cover"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/figures/eunis-habitat-types-per-biogeographic-region">
+	<accessURL xmlns="http://www.w3.org/ns/dcat#">http://www.eea.europa.eu/data-and-maps/figures/eunis-habitat-types-per-biogeographic-region</accessURL>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/eunis-habitat-classification">
+	<rdf:type rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
+	<subject xmlns="http://purl.org/dc/terms/">habitats</subject>
+	<distribution xmlns="http://www.w3.org/ns/dcat#" rdf:resource="http://www.eea.europa.eu/data-and-maps/data/eunis-habitat-classification/documentation/link-between-eunis-2007-and.xls"/>
+	<distribution xmlns="http://www.w3.org/ns/dcat#" rdf:resource="http://www.eea.europa.eu/data-and-maps/data/eunis-habitat-classification/documentation/link-eunis-and-palhab2001.xls"/>
+	<keyword xmlns="http://open-data.europa.eu/ontologies/ec-odp#">marine</keyword>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/eunis-habitat-classification/documentation/eunis-2004-report.pdf">
+	<rdf:type rdf:resource="http://www.w3.org/TR/vocab-dcat#Download"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/eunis-habitat-classification">
+	<modified xmlns="http://purl.org/dc/terms/" rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-03-06T14:26:53Z</modified>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/eunis-habitat-classification/documentation/eunis-clc.pdf">
+	<modified xmlns="http://purl.org/dc/terms/" rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2014-10-01T08:50:56Z</modified>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/eunis-habitat-classification">
+	<productID xmlns="http://schema.org/">DAT-137-en</productID>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/eunis-habitat-classification/eunis-habitat-classification-review-2017/eunis-habitat-classification-2017-revised">
+	<rdf:type rdf:resource="http://www.w3.org/TR/vocab-dcat#Download"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/eunis-habitat-classification">
+	<distribution xmlns="http://www.w3.org/ns/dcat#" rdf:resource="http://www.eea.europa.eu/data-and-maps/data/eunis-habitat-classification/documentation/eunis-habitat-classification-users-guide-v2.pdf"/>
+	<distribution xmlns="http://www.w3.org/ns/dcat#" rdf:resource="http://www.eea.europa.eu/data-and-maps/data/eunis-habitat-classification/documentation/eunis-2004-list.pdf"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/eunis-habitat-classification/eunis-marine-habitat-classification-review-2019/eunis-marine-habitat-classification-2019">
+	<accessURL xmlns="http://www.w3.org/ns/dcat#" rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.eea.europa.eu/data-and-maps/data/eunis-habitat-classification/eunis-marine-habitat-classification-review-2019/eunis-marine-habitat-classification-2019/at_download/file</accessURL>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/eunis-habitat-classification">
+	<distribution xmlns="http://www.w3.org/ns/dcat#" rdf:resource="http://www.eea.europa.eu/data-and-maps/data/eunis-habitat-classification/documentation/eunis-clc.pdf"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/eunis-habitat-classification/eunis-marine-habitat-classification-review-2019/eunis-marine-habitat-classification-2019">
+	<modified xmlns="http://purl.org/dc/terms/" rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-03-06T14:29:21Z</modified>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/figures/eunis-habitats-based-on-corine-land-cover">
+	<accessURL xmlns="http://www.w3.org/ns/dcat#">http://www.eea.europa.eu/data-and-maps/figures/eunis-habitats-based-on-corine-land-cover</accessURL>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/eunis-habitat-classification/documentation/link-eunis-and-palhab2001.xls">
+	<modified xmlns="http://purl.org/dc/terms/" rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2014-10-01T09:02:49Z</modified>
+	<accessURL xmlns="http://www.w3.org/ns/dcat#" rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.eea.europa.eu/data-and-maps/data/eunis-habitat-classification/documentation/link-eunis-and-palhab2001.xls/at_download/file</accessURL>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/eunis-habitat-classification">
+	<keyword xmlns="http://open-data.europa.eu/ontologies/ec-odp#">vegetation</keyword>
+	<theme xmlns="http://www.w3.org/ns/dcat#" rdf:resource="http://aims.fao.org/aos/agrovoc/c_8176"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/eunis-habitat-classification/eunis-marine-habitat-classification-review-2019/eunis-marine-habitat-classification-2019">
+	<rdf:type rdf:resource="http://www.w3.org/TR/vocab-dcat#Download"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/eunis-habitat-classification/habitats/eunis-habitats-complete-with-descriptions.xls">
+	<distributionFormat xmlns="http://open-data.europa.eu/ontologies/ec-odp#">application/vnd.ms-excel</distributionFormat>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/eunis-habitat-classification/documentation/eunis-2004-list.pdf">
+	<title xmlns="http://purl.org/dc/terms/" xml:lang="en">EUNIS habitat types 2004: codes and scientific names</title>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/eunis-habitat-classification">
+	<keyword xmlns="http://open-data.europa.eu/ontologies/ec-odp#">eunis habitat classification</keyword>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/eunis-habitat-classification/eunis-marine-habitat-classification-review-2019/eunis-marine-habitat-classification-2019">
+	<title xmlns="http://purl.org/dc/terms/" xml:lang="en">EUNIS marine habitat classification 2019</title>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/eunis-habitat-classification">
+	<distribution xmlns="http://www.w3.org/ns/dcat#" rdf:resource="http://www.eea.europa.eu/data-and-maps/data/eunis-habitat-classification/eunis-marine-habitat-classification-review-2019/eunis-marine-habitat-classification-2019"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/themes/biodiversity/an-introduction-to-habitats/underpinning-european-policy-on-nature-conservation-1/vegetation-eunis-habitat-suitability-map">
+	<distributionFormat xmlns="http://open-data.europa.eu/ontologies/ec-odp#">text/html</distributionFormat>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/eunis-habitat-classification">
+	<keyword xmlns="http://open-data.europa.eu/ontologies/ec-odp#">terrestrial</keyword>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/eunis-habitat-classification/documentation/eunis-2004-list.pdf">
+	<modified xmlns="http://purl.org/dc/terms/" rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2014-10-01T09:04:19Z</modified>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/eunis-habitat-classification">
+	<distribution xmlns="http://www.w3.org/ns/dcat#" rdf:resource="http://www.eea.europa.eu/data-and-maps/data/eunis-habitat-classification/documentation/eunis-2004-report.pdf"/>
+	<theme xmlns="http://www.w3.org/ns/dcat#" rdf:resource="http://eurovoc.europa.eu/5463"/>
+	<distribution xmlns="http://www.w3.org/ns/dcat#" rdf:resource="http://www.eea.europa.eu/data-and-maps/data/eunis-habitat-classification/eunis-habitat-classification-review-2017/eunis-habitat-classification-2017-revised"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/eunis-habitat-classification/eunis-habitat-classification-review-2017/eunis-habitat-classification-2017-revised">
+	<distributionFormat xmlns="http://open-data.europa.eu/ontologies/ec-odp#">application/vnd.openxmlformats-officedocument.spreadsheetml.sheet</distributionFormat>
+	<accessURL xmlns="http://www.w3.org/ns/dcat#" rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.eea.europa.eu/data-and-maps/data/eunis-habitat-classification/eunis-habitat-classification-review-2017/eunis-habitat-classification-2017-revised/at_download/file</accessURL>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/figures/eunis-habitat-types-per-biogeographic-region">
+	<distributionFormat xmlns="http://open-data.europa.eu/ontologies/ec-odp#">text/html</distributionFormat>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/eunis-habitat-classification/documentation/link-between-eunis-2007-and.xls">
+	<title xmlns="http://purl.org/dc/terms/" xml:lang="en">Crosswalk EUNIS 2007 and Annex I 2008</title>
+</rdf:Description>
+
+</rdf:RDF>

--- a/app/tests/sds_responses/DAT-150-en.rdf
+++ b/app/tests/sds_responses/DAT-150-en.rdf
@@ -1,0 +1,355 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF
+	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/media/infographics/many-europeans-are-exposed-to-2">
+	<title xmlns="http://purl.org/dc/terms/" xml:lang="en">Many Europeans are exposed to harmful levels of air pollution</title>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station">
+	<description xmlns="http://purl.org/dc/terms/" xml:lang="en">This dataset helps assess European population’s exposure to air pollutants. It provides a snapshot of air quality based on data from official monitoring stations (via Air Quality e-reporting) in the cities included in the Urban Audit project. It also shows the situation at station level in relation to the different European Union and World Health Organization air quality standards.</description>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station/air-pollutant-concentrations-2014/air-pollutant-concentrations-2014-dataset">
+	<distributionFormat xmlns="http://open-data.europa.eu/ontologies/ec-odp#">application/vnd.openxmlformats-officedocument.spreadsheetml.sheet</distributionFormat>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station/air-pollutant-concentrations-2012/air-pollutant-concentrations-2012-dataset-countries">
+	<modified xmlns="http://purl.org/dc/terms/" rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-11-30T08:23:27Z</modified>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station/pollutant-concentrations-by-city/air-pollutant-concentrations-2013-dataset-cities">
+	<rdf:type rdf:resource="http://www.w3.org/TR/vocab-dcat#Download"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station/air-pollutant-concentrations-2015/air-pollutant-concentrations-2015-compared">
+	<accessURL xmlns="http://www.w3.org/ns/dcat#" rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station/air-pollutant-concentrations-2015/air-pollutant-concentrations-2015-compared/at_download/file</accessURL>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station">
+	<distribution xmlns="http://www.w3.org/ns/dcat#" rdf:resource="http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station/air-pollutant-concentrations-2016/air-pollutant-concentrations-2016"/>
+	<keyword xmlns="http://open-data.europa.eu/ontologies/ec-odp#">cities</keyword>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station/air-pollutant-concentrations-2016/air-pollutant-concentrations-2016">
+	<modified xmlns="http://purl.org/dc/terms/" rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-01-23T12:32:04Z</modified>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station">
+	<subject xmlns="http://purl.org/dc/terms/">cities</subject>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station/air-pollutant-concentrations-2011/air-pollutant-concentrations-2011-dataset">
+	<accessURL xmlns="http://www.w3.org/ns/dcat#" rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station/air-pollutant-concentrations-2011/air-pollutant-concentrations-2011-dataset/at_download/file</accessURL>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station/air-pollutant-concentrations-2015/air-pollutant-concentrations-2015-compared">
+	<distributionFormat xmlns="http://open-data.europa.eu/ontologies/ec-odp#">application/vnd.openxmlformats-officedocument.spreadsheetml.sheet</distributionFormat>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station/air-pollutant-concentrations-2014/air-pollutant-concentrations-2014-who">
+	<accessURL xmlns="http://www.w3.org/ns/dcat#" rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station/air-pollutant-concentrations-2014/air-pollutant-concentrations-2014-who/at_download/file</accessURL>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/media/infographics/many-europeans-are-exposed-to-2">
+	<rdf:type rdf:resource="http://www.eea.europa.eu/portal_types/Infographic#Infographic"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station/air-pollutant-concentrations-2014/air-pollutant-concentrations-2014-who">
+	<distributionFormat xmlns="http://open-data.europa.eu/ontologies/ec-odp#">application/vnd.openxmlformats-officedocument.spreadsheetml.sheet</distributionFormat>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station/air-pollutant-concentrations-2014/air-pollutant-concentrations-2014-dataset">
+	<modified xmlns="http://purl.org/dc/terms/" rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-04-26T13:31:55Z</modified>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station/pollutant-concentrations-by-city/air-pollutant-concentrations-2013-dataset">
+	<modified xmlns="http://purl.org/dc/terms/" rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-11-30T08:23:24Z</modified>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station/air-pollutant-concentrations-2016/air-pollutant-concentrations-2016">
+	<rdf:type rdf:resource="http://www.w3.org/TR/vocab-dcat#Download"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station">
+	<modified xmlns="http://purl.org/dc/terms/" rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-01-23T08:33:33Z</modified>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/figures/urban-population-resident-in-areas-pollutant-limit-target">
+	<title xmlns="http://purl.org/dc/terms/" xml:lang="en">Percentage of urban population resident in areas where pollutant concentrations are higher than selected limit/target values, 2000-2012 (EU-28)</title>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station">
+	<distribution xmlns="http://www.w3.org/ns/dcat#" rdf:resource="http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station/air-pollutant-concentrations-2012/air-pollutant-concentrations-2012-dataset-countries"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station/air-pollutant-concentrations-2014/air-pollutant-concentrations-2014-dataset">
+	<accessURL xmlns="http://www.w3.org/ns/dcat#" rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station/air-pollutant-concentrations-2014/air-pollutant-concentrations-2014-dataset/at_download/file</accessURL>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station">
+	<distribution xmlns="http://www.w3.org/ns/dcat#" rdf:resource="http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station/air-pollutant-concentrations-2010/air-pollutant-concentrations-2010-dataset"/>
+	<distribution xmlns="http://www.w3.org/ns/dcat#" rdf:resource="http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station/air-pollutant-concentrations-2012/air-pollutant-concentrations-2012-dataset-cities"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station/air-pollutant-concentrations-2011/air-pollutant-concentrations-2011-dataset">
+	<rdf:type rdf:resource="http://www.w3.org/TR/vocab-dcat#Download"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station">
+	<distribution xmlns="http://www.w3.org/ns/dcat#" rdf:resource="http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station/air-pollutant-concentrations-2012/air-pollutant-concentrations-2012-dataset-complete"/>
+	<productID xmlns="http://schema.org/">DAT-150-en</productID>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/figures/urban-population-resident-in-areas-pollutant-limit-target">
+	<accessURL xmlns="http://www.w3.org/ns/dcat#">http://www.eea.europa.eu/data-and-maps/figures/urban-population-resident-in-areas-pollutant-limit-target</accessURL>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station/air-pollutant-concentrations-2014/air-pollutant-concentrations-2014-who">
+	<title xmlns="http://purl.org/dc/terms/" xml:lang="en">Air pollutant concentrations 2014 - Dataset by cities (compared to WHO guidelines)</title>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station">
+	<title xmlns="http://purl.org/dc/terms/" xml:lang="en">Air pollutant concentrations at station level (statistics)</title>
+	<subject xmlns="http://purl.org/dc/terms/">air pollutants</subject>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station/air-pollutant-concentrations-2014/air-pollutant-concentrations-2014-who">
+	<rdf:type rdf:resource="http://www.w3.org/TR/vocab-dcat#Download"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station/air-pollutant-concentrations-2016/air-pollutant-concentrations-2016-who">
+	<accessURL xmlns="http://www.w3.org/ns/dcat#" rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station/air-pollutant-concentrations-2016/air-pollutant-concentrations-2016-who/at_download/file</accessURL>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station">
+	<distribution xmlns="http://www.w3.org/ns/dcat#" rdf:resource="http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station/air-pollutant-concentrations-2011/air-pollutant-concentrations-2011-dataset"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station/air-pollutant-concentrations-2011/air-pollutant-concentrations-2011-dataset">
+	<modified xmlns="http://purl.org/dc/terms/" rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-11-30T08:23:32Z</modified>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station">
+	<subject xmlns="http://purl.org/dc/terms/" rdf:resource="http://eurovoc.europa.eu/2527"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/media/infographics/many-europeans-are-exposed-to-2">
+	<distributionFormat xmlns="http://open-data.europa.eu/ontologies/ec-odp#">text/html</distributionFormat>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station/air-pollutant-concentrations-2016/air-pollutant-concentrations-2016-who">
+	<modified xmlns="http://purl.org/dc/terms/" rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-01-23T12:32:13Z</modified>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station/pollutant-concentrations-by-city/air-pollutant-concentrations-2013-dataset">
+	<accessURL xmlns="http://www.w3.org/ns/dcat#" rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station/pollutant-concentrations-by-city/air-pollutant-concentrations-2013-dataset/at_download/file</accessURL>
+	<rdf:type rdf:resource="http://www.w3.org/TR/vocab-dcat#Download"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station/air-pollutant-concentrations-2010/air-pollutant-concentrations-2010-dataset">
+	<distributionFormat xmlns="http://open-data.europa.eu/ontologies/ec-odp#">application/vnd.openxmlformats-officedocument.spreadsheetml.sheet</distributionFormat>
+	<title xmlns="http://purl.org/dc/terms/" xml:lang="en">Air pollutant concentrations 2010 - Dataset by cities</title>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station">
+	<keyword xmlns="http://open-data.europa.eu/ontologies/ec-odp#">air quality</keyword>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station/air-pollutant-concentrations-2012/air-pollutant-concentrations-2012-dataset-complete">
+	<title xmlns="http://purl.org/dc/terms/" xml:lang="en">Air pollutant concentrations 2012 - Dataset complete</title>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station/air-pollutant-concentrations-2016/air-pollutant-concentrations-2016-who">
+	<title xmlns="http://purl.org/dc/terms/" xml:lang="en">Air pollutant concentrations 2016 (compared to WHO guidelines)</title>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station/pollutant-concentrations-by-city/air-pollutant-concentrations-2013-dataset-cities">
+	<distributionFormat xmlns="http://open-data.europa.eu/ontologies/ec-odp#">application/vnd.openxmlformats-officedocument.spreadsheetml.sheet</distributionFormat>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station/air-pollutant-concentrations-2012/air-pollutant-concentrations-2012-dataset-complete">
+	<rdf:type rdf:resource="http://www.w3.org/TR/vocab-dcat#Download"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station/pollutant-concentrations-by-city/air-pollutant-concentrations-2013-dataset-cities">
+	<title xmlns="http://purl.org/dc/terms/" xml:lang="en">Air pollutant concentrations 2013 - Dataset by cities (compared to EU values)</title>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station/air-pollutant-concentrations-2016/air-pollutant-concentrations-2016-who">
+	<rdf:type rdf:resource="http://www.w3.org/TR/vocab-dcat#Download"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station/air-pollutant-concentrations-2015/air-pollutant-concentrations-2015-compared">
+	<modified xmlns="http://purl.org/dc/terms/" rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-04-26T13:31:36Z</modified>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station">
+	<rdf:type rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station/pollutant-concentrations-by-city/air-pollutant-concentrations-2013-dataset">
+	<distributionFormat xmlns="http://open-data.europa.eu/ontologies/ec-odp#">application/vnd.openxmlformats-officedocument.spreadsheetml.sheet</distributionFormat>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station/air-pollutant-concentrations-2012/air-pollutant-concentrations-2012-dataset-cities">
+	<rdf:type rdf:resource="http://www.w3.org/TR/vocab-dcat#Download"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station/air-pollutant-concentrations-2012/air-pollutant-concentrations-2012-dataset-countries">
+	<distributionFormat xmlns="http://open-data.europa.eu/ontologies/ec-odp#">application/vnd.openxmlformats-officedocument.spreadsheetml.sheet</distributionFormat>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station">
+	<distribution xmlns="http://www.w3.org/ns/dcat#" rdf:resource="http://www.eea.europa.eu/data-and-maps/figures/urban-population-resident-in-areas-pollutant-limit-target"/>
+	<distribution xmlns="http://www.w3.org/ns/dcat#" rdf:resource="http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station/air-pollutant-concentrations-2015/air-pollutant-concentrations-2015-compared"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station/air-pollutant-concentrations-2012/air-pollutant-concentrations-2012-dataset-countries">
+	<rdf:type rdf:resource="http://www.w3.org/TR/vocab-dcat#Download"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station/air-pollutant-concentrations-2012/air-pollutant-concentrations-2012-dataset-cities">
+	<distributionFormat xmlns="http://open-data.europa.eu/ontologies/ec-odp#">application/vnd.openxmlformats-officedocument.spreadsheetml.sheet</distributionFormat>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station/pollutant-concentrations-by-city/air-pollutant-concentrations-2013-dataset">
+	<title xmlns="http://purl.org/dc/terms/" xml:lang="en">Air pollutant concentrations 2013 - Dataset by cities (compared to WHO guidelines)</title>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station/air-pollutant-concentrations-2012/air-pollutant-concentrations-2012-dataset-cities">
+	<accessURL xmlns="http://www.w3.org/ns/dcat#" rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station/air-pollutant-concentrations-2012/air-pollutant-concentrations-2012-dataset-cities/at_download/file</accessURL>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station/pollutant-concentrations-by-city/air-pollutant-concentrations-2013-dataset-cities">
+	<accessURL xmlns="http://www.w3.org/ns/dcat#" rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station/pollutant-concentrations-by-city/air-pollutant-concentrations-2013-dataset-cities/at_download/file</accessURL>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station/air-pollutant-concentrations-2012/air-pollutant-concentrations-2012-dataset-complete">
+	<distributionFormat xmlns="http://open-data.europa.eu/ontologies/ec-odp#">application/vnd.openxmlformats-officedocument.spreadsheetml.sheet</distributionFormat>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station/air-pollutant-concentrations-2012/air-pollutant-concentrations-2012-dataset-cities">
+	<modified xmlns="http://purl.org/dc/terms/" rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-11-30T08:23:30Z</modified>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station/air-pollutant-concentrations-2016/air-pollutant-concentrations-2016-who">
+	<distributionFormat xmlns="http://open-data.europa.eu/ontologies/ec-odp#">application/vnd.openxmlformats-officedocument.spreadsheetml.sheet</distributionFormat>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station/air-pollutant-concentrations-2012/air-pollutant-concentrations-2012-dataset-complete">
+	<accessURL xmlns="http://www.w3.org/ns/dcat#" rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station/air-pollutant-concentrations-2012/air-pollutant-concentrations-2012-dataset-complete/at_download/file</accessURL>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station/air-pollutant-concentrations-2012/air-pollutant-concentrations-2012-dataset-countries">
+	<title xmlns="http://purl.org/dc/terms/" xml:lang="en">Air pollutant concentrations 2012 - Dataset by countries</title>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station/air-pollutant-concentrations-2016/air-pollutant-concentrations-2016">
+	<accessURL xmlns="http://www.w3.org/ns/dcat#" rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station/air-pollutant-concentrations-2016/air-pollutant-concentrations-2016/at_download/file</accessURL>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station/air-pollutant-concentrations-2014/air-pollutant-concentrations-2014-dataset">
+	<rdf:type rdf:resource="http://www.w3.org/TR/vocab-dcat#Download"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station/air-pollutant-concentrations-2011/air-pollutant-concentrations-2011-dataset">
+	<title xmlns="http://purl.org/dc/terms/" xml:lang="en">Air pollutant concentrations 2011 - Dataset by cities</title>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station">
+	<distribution xmlns="http://www.w3.org/ns/dcat#" rdf:resource="http://www.eea.europa.eu/media/infographics/many-europeans-are-exposed-to-2"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station/air-pollutant-concentrations-2010/air-pollutant-concentrations-2010-dataset">
+	<accessURL xmlns="http://www.w3.org/ns/dcat#" rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station/air-pollutant-concentrations-2010/air-pollutant-concentrations-2010-dataset/at_download/file</accessURL>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station">
+	<issued xmlns="http://purl.org/dc/terms/" rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-10-12T11:40:00Z</issued>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station/pollutant-concentrations-by-city/air-pollutant-concentrations-2013-dataset-cities">
+	<modified xmlns="http://purl.org/dc/terms/" rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-11-30T08:23:22Z</modified>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station/air-pollutant-concentrations-2012/air-pollutant-concentrations-2012-dataset-cities">
+	<title xmlns="http://purl.org/dc/terms/" xml:lang="en">Air pollutant concentrations 2012 - Dataset by cities</title>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station/air-pollutant-concentrations-2016/air-pollutant-concentrations-2016">
+	<distributionFormat xmlns="http://open-data.europa.eu/ontologies/ec-odp#">application/vnd.openxmlformats-officedocument.spreadsheetml.sheet</distributionFormat>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station/air-pollutant-concentrations-2011/air-pollutant-concentrations-2011-dataset">
+	<distributionFormat xmlns="http://open-data.europa.eu/ontologies/ec-odp#">application/vnd.openxmlformats-officedocument.spreadsheetml.sheet</distributionFormat>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station/air-pollutant-concentrations-2016/air-pollutant-concentrations-2016">
+	<title xmlns="http://purl.org/dc/terms/" xml:lang="en">Air pollutant concentrations 2016 (compared to EU values)</title>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station">
+	<subject xmlns="http://purl.org/dc/terms/">air quality</subject>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/media/infographics/many-europeans-are-exposed-to-2">
+	<accessURL xmlns="http://www.w3.org/ns/dcat#">http://www.eea.europa.eu/media/infographics/many-europeans-are-exposed-to-2</accessURL>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station/air-pollutant-concentrations-2015/air-pollutant-concentrations-2015-compared">
+	<title xmlns="http://purl.org/dc/terms/" xml:lang="en">Air pollutant concentrations 2015 (compared to EU values)</title>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station/air-pollutant-concentrations-2014/air-pollutant-concentrations-2014-who">
+	<modified xmlns="http://purl.org/dc/terms/" rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-04-26T13:31:56Z</modified>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station">
+	<distribution xmlns="http://www.w3.org/ns/dcat#" rdf:resource="http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station/air-pollutant-concentrations-2014/air-pollutant-concentrations-2014-who"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station/air-pollutant-concentrations-2010/air-pollutant-concentrations-2010-dataset">
+	<modified xmlns="http://purl.org/dc/terms/" rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-11-30T08:23:37Z</modified>
+	<rdf:type rdf:resource="http://www.w3.org/TR/vocab-dcat#Download"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/figures/urban-population-resident-in-areas-pollutant-limit-target">
+	<distributionFormat xmlns="http://open-data.europa.eu/ontologies/ec-odp#">text/html</distributionFormat>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station/air-pollutant-concentrations-2014/air-pollutant-concentrations-2014-dataset">
+	<title xmlns="http://purl.org/dc/terms/" xml:lang="en">Air pollutant concentrations 2014 - Dataset by cities (compared to EU values)</title>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station">
+	<distribution xmlns="http://www.w3.org/ns/dcat#" rdf:resource="http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station/pollutant-concentrations-by-city/air-pollutant-concentrations-2013-dataset-cities"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station/air-pollutant-concentrations-2015/air-pollutant-concentrations-2015-compared">
+	<rdf:type rdf:resource="http://www.w3.org/TR/vocab-dcat#Download"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station/air-pollutant-concentrations-2012/air-pollutant-concentrations-2012-dataset-countries">
+	<accessURL xmlns="http://www.w3.org/ns/dcat#" rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station/air-pollutant-concentrations-2012/air-pollutant-concentrations-2012-dataset-countries/at_download/file</accessURL>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station">
+	<distribution xmlns="http://www.w3.org/ns/dcat#" rdf:resource="http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station/pollutant-concentrations-by-city/air-pollutant-concentrations-2013-dataset"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station/air-pollutant-concentrations-2012/air-pollutant-concentrations-2012-dataset-complete">
+	<modified xmlns="http://purl.org/dc/terms/" rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-11-30T08:23:25Z</modified>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station">
+	<keyword xmlns="http://open-data.europa.eu/ontologies/ec-odp#">air pollutants</keyword>
+	<distribution xmlns="http://www.w3.org/ns/dcat#" rdf:resource="http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station/air-pollutant-concentrations-2014/air-pollutant-concentrations-2014-dataset"/>
+	<distribution xmlns="http://www.w3.org/ns/dcat#" rdf:resource="http://www.eea.europa.eu/data-and-maps/data/air-pollutant-concentrations-at-station/air-pollutant-concentrations-2016/air-pollutant-concentrations-2016-who"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/figures/urban-population-resident-in-areas-pollutant-limit-target">
+	<rdf:type rdf:resource="http://www.eea.europa.eu/portal_types/EEAFigure#EEAFigure"/>
+</rdf:Description>
+
+</rdf:RDF>

--- a/app/tests/sds_responses/DAT-176-en.rdf
+++ b/app/tests/sds_responses/DAT-176-en.rdf
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF
+	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/fuel-quality-directive-1">
+	<theme xmlns="http://www.w3.org/ns/dcat#" rdf:resource="http://aims.fao.org/aos/agrovoc/c_2565"/>
+	<theme xmlns="http://www.w3.org/ns/dcat#" rdf:resource="http://aims.fao.org/aos/agrovoc/c_7874"/>
+	<distribution xmlns="http://www.w3.org/ns/dcat#" rdf:resource="http://www.eea.europa.eu/data-and-maps/dashboards/fuel-quality-article-8"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/dashboards/fuel-quality-article-8">
+	<distributionFormat xmlns="http://open-data.europa.eu/ontologies/ec-odp#">text/html</distributionFormat>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/fuel-quality-directive-1">
+	<subject xmlns="http://purl.org/dc/terms/">fqd</subject>
+	<rdf:type rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/dashboards/fuel-quality-article-8">
+	<accessURL xmlns="http://www.w3.org/ns/dcat#">http://www.eea.europa.eu/data-and-maps/dashboards/fuel-quality-article-8</accessURL>
+	<rdf:type rdf:resource="http://www.eea.europa.eu/portal_types/Dashboard#Dashboard"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/fuel-quality-directive-1">
+	<description xmlns="http://purl.org/dc/terms/" xml:lang="en">By 31st of August each year the Member States must submit a summary of fuel quality monitoring data collected during the period January to December of the previous calendar year, in accordance with Article 8(1) of Directive 98/70/EC as amended by Directive 2009/30/EC. The delivery process is managed by EEA.</description>
+	<title xmlns="http://purl.org/dc/terms/" xml:lang="en">Fuel Quality Directive</title>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/dashboards/fuel-quality-article-8">
+	<title xmlns="http://purl.org/dc/terms/" xml:lang="en">Petrol and diesel fuels sold for road transport</title>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/fuel-quality-directive">
+	<description xmlns="http://purl.org/dc/terms/" xml:lang="en">By 31st of August each year the Member States must submit a summary of fuel quality monitoring data collected during the period January to December of the previous calendar year, in accordance with Article 8(1) of Directive 98/70/EC as amended by Directive 2009/30/EC. The delivery process is managed by EEA.</description>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/fuel-quality-directive-1">
+	<modified xmlns="http://purl.org/dc/terms/" rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-06-24T10:52:47Z</modified>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/fuel-quality-directive">
+	<issued xmlns="http://purl.org/dc/terms/" rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018-07-03T11:50:00Z</issued>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/fuel-quality-directive-1">
+	<issued xmlns="http://purl.org/dc/terms/" rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2020-06-24T10:52:47Z</issued>
+	<keyword xmlns="http://open-data.europa.eu/ontologies/ec-odp#">fqd</keyword>
+	<productID xmlns="http://schema.org/">DAT-176-en</productID>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/fuel-quality-directive">
+	<rdf:type rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/fuel-quality-directive-1">
+	<replaces xmlns="http://purl.org/dc/terms/" rdf:resource="http://www.eea.europa.eu/data-and-maps/data/fuel-quality-directive"/>
+</rdf:Description>
+
+</rdf:RDF>

--- a/app/tests/sds_responses/DAT-86-en.rdf
+++ b/app/tests/sds_responses/DAT-86-en.rdf
@@ -1,0 +1,268 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF
+	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/interpolated-air-quality-data">
+	<spatial xmlns="http://purl.org/dc/terms/" rdf:resource="http://publications.europa.eu/resource/authority/country/HRV"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/figures/ozone-aot40-for-crops-2004">
+	<distributionFormat xmlns="http://open-data.europa.eu/ontologies/ec-odp#">text/html</distributionFormat>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/figures/nox-annual-average-2004">
+	<title xmlns="http://purl.org/dc/terms/" xml:lang="en">NOx annual average, 2004</title>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/interpolated-air-quality-data">
+	<distribution xmlns="http://www.w3.org/ns/dcat#" rdf:resource="http://www.eea.europa.eu/data-and-maps/figures/ozone-somo35-2004"/>
+	<spatial xmlns="http://purl.org/dc/terms/" rdf:resource="http://publications.europa.eu/resource/authority/country/IRL"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/figures/ozone-somo35-2004">
+	<accessURL xmlns="http://www.w3.org/ns/dcat#">http://www.eea.europa.eu/data-and-maps/figures/ozone-somo35-2004</accessURL>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/interpolated-air-quality-data">
+	<spatial xmlns="http://purl.org/dc/terms/" rdf:resource="http://publications.europa.eu/resource/authority/country/HUN"/>
+	<subject xmlns="http://purl.org/dc/terms/">air quality</subject>
+	<subject xmlns="http://purl.org/dc/terms/" rdf:resource="http://eurovoc.europa.eu/3967"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/interpolated-air-quality-data/zipped-shape-files-with-interpolated-air-quality-data-vector-format/zipped-shape-files-with-interpolated-air-quality-data-vector-format">
+	<accessURL xmlns="http://www.w3.org/ns/dcat#" rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://www.eea.europa.eu/data-and-maps/data/interpolated-air-quality-data/zipped-shape-files-with-interpolated-air-quality-data-vector-format/zipped-shape-files-with-interpolated-air-quality-data-vector-format/at_download/file</accessURL>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/interpolated-air-quality-data">
+	<spatial xmlns="http://purl.org/dc/terms/" rdf:resource="http://publications.europa.eu/resource/authority/country/GBR"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/figures/so2-annual-average-2004">
+	<title xmlns="http://purl.org/dc/terms/" xml:lang="en">SO2 annual average, 2004</title>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/interpolated-air-quality-data">
+	<spatial xmlns="http://purl.org/dc/terms/" rdf:resource="http://publications.europa.eu/resource/authority/country/GRC"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/figures/nox-annual-average-2004">
+	<distributionFormat xmlns="http://open-data.europa.eu/ontologies/ec-odp#">text/html</distributionFormat>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/interpolated-air-quality-data/zipped-shape-files-with-interpolated-air-quality-data-vector-format/zipped-shape-files-with-interpolated-air-quality-data-vector-format">
+	<distributionFormat xmlns="http://open-data.europa.eu/ontologies/ec-odp#">application/zip</distributionFormat>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/figures/nox-annual-average-2004">
+	<accessURL xmlns="http://www.w3.org/ns/dcat#">http://www.eea.europa.eu/data-and-maps/figures/nox-annual-average-2004</accessURL>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/interpolated-air-quality-data">
+	<distribution xmlns="http://www.w3.org/ns/dcat#" rdf:resource="http://www.eea.europa.eu/data-and-maps/data/interpolated-air-quality-data/zipped-shape-files-with-interpolated-air-quality-data-vector-format/zipped-shape-files-with-interpolated-air-quality-data-vector-format"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/figures/pm10-36th-maximum-daily-average-2004">
+	<distributionFormat xmlns="http://open-data.europa.eu/ontologies/ec-odp#">text/html</distributionFormat>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/interpolated-air-quality-data">
+	<productID xmlns="http://schema.org/">DAT-86-en</productID>
+	<modified xmlns="http://purl.org/dc/terms/" rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-08-25T11:59:55Z</modified>
+	<spatial xmlns="http://purl.org/dc/terms/" rdf:resource="http://publications.europa.eu/resource/authority/country/DNK"/>
+	<spatial xmlns="http://purl.org/dc/terms/" rdf:resource="http://publications.europa.eu/resource/authority/country/FIN"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/figures/pm10-36th-maximum-daily-average-2004">
+	<accessURL xmlns="http://www.w3.org/ns/dcat#">http://www.eea.europa.eu/data-and-maps/figures/pm10-36th-maximum-daily-average-2004</accessURL>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/interpolated-air-quality-data">
+	<spatial xmlns="http://purl.org/dc/terms/" rdf:resource="http://publications.europa.eu/resource/authority/country/FRA"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/figures/ozone-somo35-2004">
+	<title xmlns="http://purl.org/dc/terms/" xml:lang="en">Ozone SOMO35, 2004</title>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/interpolated-air-quality-data">
+	<spatial xmlns="http://purl.org/dc/terms/" rdf:resource="http://publications.europa.eu/resource/authority/country/ESP"/>
+	<spatial xmlns="http://purl.org/dc/terms/" rdf:resource="http://publications.europa.eu/resource/authority/country/EST"/>
+	<subject xmlns="http://purl.org/dc/terms/">geospatial data</subject>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/figures/so2-annual-average-2004">
+	<rdf:type rdf:resource="http://www.eea.europa.eu/portal_types/EEAFigure#EEAFigure"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/interpolated-air-quality-data">
+	<spatial xmlns="http://purl.org/dc/terms/" rdf:resource="http://publications.europa.eu/resource/authority/country/POL"/>
+	<distribution xmlns="http://www.w3.org/ns/dcat#" rdf:resource="http://www.eea.europa.eu/data-and-maps/figures/ozone-aot40-for-crops-2004"/>
+	<keyword xmlns="http://open-data.europa.eu/ontologies/ec-odp#">geospatial data</keyword>
+	<keyword xmlns="http://open-data.europa.eu/ontologies/ec-odp#">vector data</keyword>
+	<spatial xmlns="http://purl.org/dc/terms/" rdf:resource="http://publications.europa.eu/resource/authority/country/ROU"/>
+	<spatial xmlns="http://purl.org/dc/terms/" rdf:resource="http://publications.europa.eu/resource/authority/country/PRT"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/interpolated-air-quality-data/zipped-shape-files-with-interpolated-air-quality-data-vector-format/zipped-shape-files-with-interpolated-air-quality-data-vector-format">
+	<rdf:type rdf:resource="http://www.w3.org/TR/vocab-dcat#Download"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/interpolated-air-quality-data">
+	<spatial xmlns="http://purl.org/dc/terms/" rdf:resource="http://publications.europa.eu/resource/authority/country/CYP"/>
+	<distribution xmlns="http://www.w3.org/ns/dcat#" rdf:resource="http://www.eea.europa.eu/data-and-maps/figures/ozone-26th-highest-maximum-daily-8-hour-average-2004"/>
+	<spatial xmlns="http://purl.org/dc/terms/" rdf:resource="http://publications.europa.eu/resource/authority/country/CZE"/>
+	<isReplacedBy xmlns="http://purl.org/dc/terms/" rdf:resource="http://www.eea.europa.eu/data-and-maps/data/interpolated-air-quality-data-1"/>
+	<spatial xmlns="http://purl.org/dc/terms/" rdf:resource="http://publications.europa.eu/resource/authority/country/DEU"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/figures/nox-annual-average-2004">
+	<rdf:type rdf:resource="http://www.eea.europa.eu/portal_types/EEAFigure#EEAFigure"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/figures/pm10-annual-average-2004">
+	<rdf:type rdf:resource="http://www.eea.europa.eu/portal_types/EEAFigure#EEAFigure"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/interpolated-air-quality-data">
+	<spatial xmlns="http://purl.org/dc/terms/" rdf:resource="http://publications.europa.eu/resource/authority/country/NLD"/>
+	<issued xmlns="http://purl.org/dc/terms/" rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2008-07-18T00:00:00Z</issued>
+	<spatial xmlns="http://purl.org/dc/terms/" rdf:resource="http://publications.europa.eu/resource/authority/country/NOR"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/figures/ozone-aot40-for-crops-2004">
+	<rdf:type rdf:resource="http://www.eea.europa.eu/portal_types/EEAFigure#EEAFigure"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/interpolated-air-quality-data">
+	<spatial xmlns="http://purl.org/dc/terms/" rdf:resource="http://publications.europa.eu/resource/authority/country/SVN"/>
+	<spatial xmlns="http://purl.org/dc/terms/" rdf:resource="http://publications.europa.eu/resource/authority/country/SWE"/>
+	<spatial xmlns="http://purl.org/dc/terms/" rdf:resource="http://publications.europa.eu/resource/authority/country/MLT"/>
+	<description xmlns="http://purl.org/dc/terms/" xml:lang="en">Interpolated maps showing air quality in Europe</description>
+	<spatial xmlns="http://purl.org/dc/terms/" rdf:resource="http://publications.europa.eu/resource/authority/country/CHE"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/figures/pm10-annual-average-2004">
+	<accessURL xmlns="http://www.w3.org/ns/dcat#">http://www.eea.europa.eu/data-and-maps/figures/pm10-annual-average-2004</accessURL>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/interpolated-air-quality-data">
+	<spatial xmlns="http://purl.org/dc/terms/" rdf:resource="http://publications.europa.eu/resource/authority/country/MNE"/>
+	<spatial xmlns="http://purl.org/dc/terms/" rdf:resource="http://publications.europa.eu/resource/authority/country/SVK"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/figures/ozone-26th-highest-maximum-daily-8-hour-average-2004">
+	<title xmlns="http://purl.org/dc/terms/" xml:lang="en">Ozone 26th highest maximum daily 8-hour average 2004</title>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/interpolated-air-quality-data">
+	<distribution xmlns="http://www.w3.org/ns/dcat#" rdf:resource="http://www.eea.europa.eu/data-and-maps/figures/pm10-annual-average-2004"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/figures/so2-annual-average-2004">
+	<distributionFormat xmlns="http://open-data.europa.eu/ontologies/ec-odp#">text/html</distributionFormat>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/figures/pm10-annual-average-2004">
+	<distributionFormat xmlns="http://open-data.europa.eu/ontologies/ec-odp#">text/html</distributionFormat>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/interpolated-air-quality-data">
+	<spatial xmlns="http://purl.org/dc/terms/" rdf:resource="http://publications.europa.eu/resource/authority/country/BEL"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/figures/ozone-26th-highest-maximum-daily-8-hour-average-2004">
+	<distributionFormat xmlns="http://open-data.europa.eu/ontologies/ec-odp#">text/html</distributionFormat>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/interpolated-air-quality-data">
+	<spatial xmlns="http://purl.org/dc/terms/" rdf:resource="http://publications.europa.eu/resource/authority/country/AUT"/>
+	<spatial xmlns="http://purl.org/dc/terms/" rdf:resource="http://publications.europa.eu/resource/authority/country/LIE"/>
+	<subject xmlns="http://purl.org/dc/terms/">air</subject>
+	<spatial xmlns="http://purl.org/dc/terms/" rdf:resource="http://publications.europa.eu/resource/authority/country/BIH"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/interpolated-air-quality-data/zipped-shape-files-with-interpolated-air-quality-data-vector-format/zipped-shape-files-with-interpolated-air-quality-data-vector-format">
+	<modified xmlns="http://purl.org/dc/terms/" rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2017-08-25T11:59:56Z</modified>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/figures/so2-annual-average-2004">
+	<accessURL xmlns="http://www.w3.org/ns/dcat#">http://www.eea.europa.eu/data-and-maps/figures/so2-annual-average-2004</accessURL>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/interpolated-air-quality-data">
+	<spatial xmlns="http://purl.org/dc/terms/" rdf:resource="http://publications.europa.eu/resource/authority/country/LTU"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/figures/pm10-36th-maximum-daily-average-2004">
+	<rdf:type rdf:resource="http://www.eea.europa.eu/portal_types/EEAFigure#EEAFigure"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/interpolated-air-quality-data">
+	<subject xmlns="http://purl.org/dc/terms/">vector data</subject>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/figures/ozone-somo35-2004">
+	<distributionFormat xmlns="http://open-data.europa.eu/ontologies/ec-odp#">text/html</distributionFormat>
+	<rdf:type rdf:resource="http://www.eea.europa.eu/portal_types/EEAFigure#EEAFigure"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/interpolated-air-quality-data">
+	<spatial xmlns="http://purl.org/dc/terms/" rdf:resource="http://publications.europa.eu/resource/authority/country/BGR"/>
+	<distribution xmlns="http://www.w3.org/ns/dcat#" rdf:resource="http://www.eea.europa.eu/data-and-maps/figures/pm10-36th-maximum-daily-average-2004"/>
+	<spatial xmlns="http://purl.org/dc/terms/" rdf:resource="http://publications.europa.eu/resource/authority/country/SRB"/>
+	<spatial xmlns="http://purl.org/dc/terms/" rdf:resource="http://publications.europa.eu/resource/authority/country/LUX"/>
+	<spatial xmlns="http://purl.org/dc/terms/" rdf:resource="http://publications.europa.eu/resource/authority/country/LVA"/>
+	<isReplacedBy xmlns="http://purl.org/dc/terms/" rdf:resource="http://www.eea.europa.eu/data-and-maps/data/interpolated-air-quality-data-2"/>
+	<subject xmlns="http://purl.org/dc/terms/" rdf:resource="http://eurovoc.europa.eu/2527"/>
+	<spatial xmlns="http://purl.org/dc/terms/" rdf:resource="http://publications.europa.eu/resource/authority/country/ALB"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/figures/ozone-26th-highest-maximum-daily-8-hour-average-2004">
+	<accessURL xmlns="http://www.w3.org/ns/dcat#">http://www.eea.europa.eu/data-and-maps/figures/ozone-26th-highest-maximum-daily-8-hour-average-2004</accessURL>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/figures/ozone-aot40-for-crops-2004">
+	<title xmlns="http://purl.org/dc/terms/" xml:lang="en">Ozone AOT40 for crops, 2004</title>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/interpolated-air-quality-data">
+	<title xmlns="http://purl.org/dc/terms/" xml:lang="en">Interpolated air quality data</title>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/interpolated-air-quality-data/zipped-shape-files-with-interpolated-air-quality-data-vector-format/zipped-shape-files-with-interpolated-air-quality-data-vector-format">
+	<title xmlns="http://purl.org/dc/terms/" xml:lang="en">Zipped shape files with interpolated air quality data, vector format</title>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/interpolated-air-quality-data">
+	<distribution xmlns="http://www.w3.org/ns/dcat#" rdf:resource="http://www.eea.europa.eu/data-and-maps/figures/so2-annual-average-2004"/>
+	<spatial xmlns="http://purl.org/dc/terms/" rdf:resource="http://publications.europa.eu/resource/authority/country/ISL"/>
+	<keyword xmlns="http://open-data.europa.eu/ontologies/ec-odp#">air</keyword>
+	<spatial xmlns="http://purl.org/dc/terms/" rdf:resource="http://publications.europa.eu/resource/authority/country/ITA"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/figures/ozone-aot40-for-crops-2004">
+	<accessURL xmlns="http://www.w3.org/ns/dcat#">http://www.eea.europa.eu/data-and-maps/figures/ozone-aot40-for-crops-2004</accessURL>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/interpolated-air-quality-data">
+	<keyword xmlns="http://open-data.europa.eu/ontologies/ec-odp#">air quality</keyword>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/figures/ozone-26th-highest-maximum-daily-8-hour-average-2004">
+	<rdf:type rdf:resource="http://www.eea.europa.eu/portal_types/EEAFigure#EEAFigure"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/figures/pm10-36th-maximum-daily-average-2004">
+	<title xmlns="http://purl.org/dc/terms/" xml:lang="en">PM10 36th maximum daily average, 2004</title>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/figures/pm10-annual-average-2004">
+	<title xmlns="http://purl.org/dc/terms/" xml:lang="en">PM10 annual average, 2004</title>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://www.eea.europa.eu/data-and-maps/data/interpolated-air-quality-data">
+	<distribution xmlns="http://www.w3.org/ns/dcat#" rdf:resource="http://www.eea.europa.eu/data-and-maps/figures/nox-annual-average-2004"/>
+	<rdf:type rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
+</rdf:Description>
+
+</rdf:RDF>

--- a/app/tests/test_odp.py
+++ b/app/tests/test_odp.py
@@ -18,12 +18,7 @@ from sdsclient import (
 from .conftest import mock_sds
 
 
-def test_query_sds_and_render_rdf(mocker):
-    product_id = "DAT-21-en"
-    dataset_url = (
-        "http://www.eea.europa.eu/data-and-maps/data/"
-        "european-union-emissions-trading-scheme-13"
-    )
+def dataset_to_graph(mocker, product_id, dataset_url):
     cc = ckanclient.CKANClient("odp_queue")
 
     mocker.patch.object(cc.odp, "package_show").return_value = None
@@ -36,6 +31,16 @@ def test_query_sds_and_render_rdf(mocker):
     ckan_rdf = package_save.call_args[0][1]
 
     g = Graph().parse(data=ckan_rdf)
+    return g
+
+
+def test_query_sds_and_render_rdf(mocker):
+    product_id = "DAT-21-en"
+    dataset_url = (
+        "http://www.eea.europa.eu/data-and-maps/data/"
+        "european-union-emissions-trading-scheme-13"
+    )
+    g = dataset_to_graph(mocker, product_id, dataset_url)
 
     dataset = URIRef("http://data.europa.eu/88u/dataset/" + product_id)
     assert g.value(dataset, DCTERMS.identifier) == Literal(product_id)
@@ -258,109 +263,3 @@ def test_preserve_odp_eurovoc_concepts(mocker):
     assert set(g.objects(dataset, DCTERMS.subject)) == {
         EUROVOC[c] for c in ["5650", "434843", "6011", "1352"]
     }
-
-
-def test_query_sds_retrieve_forward_eea_figures_related_items(mocker):
-    product_id = "DAT-137-en"
-    dataset_url = (
-        "http://www.eea.europa.eu/data-and-maps/data/"
-        "eunis-habitat-classification"
-    )
-    cc = ckanclient.CKANClient("odp_queue")
-
-    mocker.patch.object(cc.odp, "package_show").return_value = None
-    mocker.patch.object(cc.sds, "get_latest_version").side_effect = lambda d: d
-
-    package_save = mocker.patch.object(cc.odp, "package_save")
-    with mock_sds(mocker, product_id + ".rdf"):
-        cc.publish_dataset(dataset_url)
-
-    ckan_rdf = package_save.call_args[0][1]
-
-    g = Graph().parse(data=ckan_rdf)
-
-    dataset = URIRef("http://data.europa.eu/88u/dataset/" + product_id)
-    assert g.value(dataset, DCTERMS.identifier) == Literal(product_id)
-
-    dist = {}
-    for d in g.objects(dataset, DCAT.distribution):
-        url = g.value(d, DCAT.accessURL).toPython()
-        assert url
-        dist[url] = d
-
-    eeafigure_url = (
-        "https://www.eea.europa.eu/data-and-maps/figures/"
-        "eunis-habitat-types-per-biogeographic-region"
-    )
-    dist_eeafigure = dist[eeafigure_url]
-    assert g.value(dist_eeafigure, DCTERMS.title) == Literal(
-        "EUNIS habitat types per biogeographic region", lang="en"
-    )
-    assert g.value(dist_eeafigure, DCTERMS["format"]) == EU_FILE_TYPE.HTML
-    assert (
-            g.value(dist_eeafigure, DCTERMS.type) == EU_DISTRIBUTION_TYPE.VISUALIZATION
-    )
-    assert g.value(dist_eeafigure, DCTERMS.license) == EU_LICENSE.CC_BY_4_0
-    assert g.value(dist_eeafigure, ADMS.status) == EU_STATUS.COMPLETED
-    assert g.value(dist_eeafigure, DCAT.accessURL) == URIRef(eeafigure_url)
-
-
-def test_query_sds_retrieve_backward_related_items(mocker):
-    product_id = "DAT-150-en"
-    dataset_url = (
-        "http://www.eea.europa.eu/data-and-maps/data/"
-        "air-pollutant-concentrations-at-station"
-    )
-    cc = ckanclient.CKANClient("odp_queue")
-
-    mocker.patch.object(cc.odp, "package_show").return_value = None
-    mocker.patch.object(cc.sds, "get_latest_version").side_effect = lambda d: d
-
-    package_save = mocker.patch.object(cc.odp, "package_save")
-    with mock_sds(mocker, product_id + ".rdf"):
-        cc.publish_dataset(dataset_url)
-
-    ckan_rdf = package_save.call_args[0][1]
-
-    g = Graph().parse(data=ckan_rdf)
-
-    dataset = URIRef("http://data.europa.eu/88u/dataset/" + product_id)
-    assert g.value(dataset, DCTERMS.identifier) == Literal(product_id)
-
-    dist = {}
-    for d in g.objects(dataset, DCAT.distribution):
-        url = g.value(d, DCAT.accessURL).toPython()
-        assert url
-        dist[url] = d
-    backward_infographic_url = (
-        "https://www.eea.europa.eu/media/infographics/"
-        "many-europeans-are-exposed-to-2"
-    )
-    dist_infograhic = dist[backward_infographic_url]
-    assert g.value(dist_infograhic, DCTERMS.title) == Literal(
-        "Many Europeans are exposed to harmful levels of air pollution", lang="en"
-    )
-    assert g.value(dist_infograhic, DCTERMS["format"]) == EU_FILE_TYPE.HTML
-    assert (
-            g.value(dist_infograhic, DCTERMS.type) == EU_DISTRIBUTION_TYPE.VISUALIZATION
-    )
-    assert g.value(dist_infograhic, DCTERMS.license) == EU_LICENSE.CC_BY_4_0
-    assert g.value(dist_infograhic, ADMS.status) == EU_STATUS.COMPLETED
-    assert g.value(dist_infograhic, DCAT.accessURL) == URIRef(backward_infographic_url)
-
-    backward_eea_figure_url = (
-        "https://www.eea.europa.eu/data-and-maps/figures/"
-        "urban-population-resident-in-areas-pollutant-limit-target"
-    )
-    dist_eea_figure = dist[backward_eea_figure_url]
-    assert g.value(dist_eea_figure, DCTERMS.title) == Literal(
-        "Percentage of urban population resident in areas where pollutant concentrations "
-        "are higher than selected limit/target values, 2000-2012 (EU-28)", lang="en"
-    )
-    assert g.value(dist_eea_figure, DCTERMS["format"]) == EU_FILE_TYPE.HTML
-    assert (
-            g.value(dist_eea_figure, DCTERMS.type) == EU_DISTRIBUTION_TYPE.VISUALIZATION
-    )
-    assert g.value(dist_eea_figure, DCTERMS.license) == EU_LICENSE.CC_BY_4_0
-    assert g.value(dist_eea_figure, ADMS.status) == EU_STATUS.COMPLETED
-    assert g.value(dist_eea_figure, DCAT.accessURL) == URIRef(backward_eea_figure_url)

--- a/app/tests/test_odp.py
+++ b/app/tests/test_odp.py
@@ -258,3 +258,109 @@ def test_preserve_odp_eurovoc_concepts(mocker):
     assert set(g.objects(dataset, DCTERMS.subject)) == {
         EUROVOC[c] for c in ["5650", "434843", "6011", "1352"]
     }
+
+
+def test_query_sds_retrieve_forward_eea_figures_related_items(mocker):
+    product_id = "DAT-137-en"
+    dataset_url = (
+        "http://www.eea.europa.eu/data-and-maps/data/"
+        "eunis-habitat-classification"
+    )
+    cc = ckanclient.CKANClient("odp_queue")
+
+    mocker.patch.object(cc.odp, "package_show").return_value = None
+    mocker.patch.object(cc.sds, "get_latest_version").side_effect = lambda d: d
+
+    package_save = mocker.patch.object(cc.odp, "package_save")
+    with mock_sds(mocker, product_id + ".rdf"):
+        cc.publish_dataset(dataset_url)
+
+    ckan_rdf = package_save.call_args[0][1]
+
+    g = Graph().parse(data=ckan_rdf)
+
+    dataset = URIRef("http://data.europa.eu/88u/dataset/" + product_id)
+    assert g.value(dataset, DCTERMS.identifier) == Literal(product_id)
+
+    dist = {}
+    for d in g.objects(dataset, DCAT.distribution):
+        url = g.value(d, DCAT.accessURL).toPython()
+        assert url
+        dist[url] = d
+
+    eeafigure_url = (
+        "https://www.eea.europa.eu/data-and-maps/figures/"
+        "eunis-habitat-types-per-biogeographic-region"
+    )
+    dist_eeafigure = dist[eeafigure_url]
+    assert g.value(dist_eeafigure, DCTERMS.title) == Literal(
+        "EUNIS habitat types per biogeographic region", lang="en"
+    )
+    assert g.value(dist_eeafigure, DCTERMS["format"]) == EU_FILE_TYPE.HTML
+    assert (
+            g.value(dist_eeafigure, DCTERMS.type) == EU_DISTRIBUTION_TYPE.VISUALIZATION
+    )
+    assert g.value(dist_eeafigure, DCTERMS.license) == EU_LICENSE.CC_BY_4_0
+    assert g.value(dist_eeafigure, ADMS.status) == EU_STATUS.COMPLETED
+    assert g.value(dist_eeafigure, DCAT.accessURL) == URIRef(eeafigure_url)
+
+
+def test_query_sds_retrieve_backward_related_items(mocker):
+    product_id = "DAT-150-en"
+    dataset_url = (
+        "http://www.eea.europa.eu/data-and-maps/data/"
+        "air-pollutant-concentrations-at-station"
+    )
+    cc = ckanclient.CKANClient("odp_queue")
+
+    mocker.patch.object(cc.odp, "package_show").return_value = None
+    mocker.patch.object(cc.sds, "get_latest_version").side_effect = lambda d: d
+
+    package_save = mocker.patch.object(cc.odp, "package_save")
+    with mock_sds(mocker, product_id + ".rdf"):
+        cc.publish_dataset(dataset_url)
+
+    ckan_rdf = package_save.call_args[0][1]
+
+    g = Graph().parse(data=ckan_rdf)
+
+    dataset = URIRef("http://data.europa.eu/88u/dataset/" + product_id)
+    assert g.value(dataset, DCTERMS.identifier) == Literal(product_id)
+
+    dist = {}
+    for d in g.objects(dataset, DCAT.distribution):
+        url = g.value(d, DCAT.accessURL).toPython()
+        assert url
+        dist[url] = d
+    backward_infographic_url = (
+        "https://www.eea.europa.eu/media/infographics/"
+        "many-europeans-are-exposed-to-2"
+    )
+    dist_infograhic = dist[backward_infographic_url]
+    assert g.value(dist_infograhic, DCTERMS.title) == Literal(
+        "Many Europeans are exposed to harmful levels of air pollution", lang="en"
+    )
+    assert g.value(dist_infograhic, DCTERMS["format"]) == EU_FILE_TYPE.HTML
+    assert (
+            g.value(dist_infograhic, DCTERMS.type) == EU_DISTRIBUTION_TYPE.VISUALIZATION
+    )
+    assert g.value(dist_infograhic, DCTERMS.license) == EU_LICENSE.CC_BY_4_0
+    assert g.value(dist_infograhic, ADMS.status) == EU_STATUS.COMPLETED
+    assert g.value(dist_infograhic, DCAT.accessURL) == URIRef(backward_infographic_url)
+
+    backward_eea_figure_url = (
+        "https://www.eea.europa.eu/data-and-maps/figures/"
+        "urban-population-resident-in-areas-pollutant-limit-target"
+    )
+    dist_eea_figure = dist[backward_eea_figure_url]
+    assert g.value(dist_eea_figure, DCTERMS.title) == Literal(
+        "Percentage of urban population resident in areas where pollutant concentrations "
+        "are higher than selected limit/target values, 2000-2012 (EU-28)", lang="en"
+    )
+    assert g.value(dist_eea_figure, DCTERMS["format"]) == EU_FILE_TYPE.HTML
+    assert (
+            g.value(dist_eea_figure, DCTERMS.type) == EU_DISTRIBUTION_TYPE.VISUALIZATION
+    )
+    assert g.value(dist_eea_figure, DCTERMS.license) == EU_LICENSE.CC_BY_4_0
+    assert g.value(dist_eea_figure, ADMS.status) == EU_STATUS.COMPLETED
+    assert g.value(dist_eea_figure, DCAT.accessURL) == URIRef(backward_eea_figure_url)

--- a/app/tests/test_odp_related_items.py
+++ b/app/tests/test_odp_related_items.py
@@ -1,0 +1,228 @@
+"""
+    This test suite checks that all the requested visualisation types are obtained in the sparql queries.
+    Each test checks for either a forward or backward visualisation related item.
+"""
+
+from rdflib import Graph, Literal, URIRef
+from rdflib.namespace import DCTERMS
+
+import ckanclient
+from sdsclient import (
+    DCAT,
+    VCARD,
+    ADMS,
+    SCHEMA,
+    EU_FILE_TYPE,
+    EU_DISTRIBUTION_TYPE,
+    EU_LICENSE,
+    EU_STATUS,
+    EU_COUNTRY,
+    EUROVOC,
+)
+
+from .conftest import mock_sds
+
+
+def dataset_to_graph(mocker, product_id, dataset_url):
+    cc = ckanclient.CKANClient("odp_queue")
+
+    mocker.patch.object(cc.odp, "package_show").return_value = None
+    mocker.patch.object(cc.sds, "get_latest_version").side_effect = lambda d: d
+
+    package_save = mocker.patch.object(cc.odp, "package_save")
+    with mock_sds(mocker, product_id + ".rdf"):
+        cc.publish_dataset(dataset_url)
+
+    ckan_rdf = package_save.call_args[0][1]
+
+    g = Graph().parse(data=ckan_rdf)
+    return g
+
+
+def test_query_retrieve_forward_eea_figures(mocker):
+    product_id = "DAT-137-en"
+    dataset_url = (
+        "http://www.eea.europa.eu/data-and-maps/data/"
+        "eunis-habitat-classification"
+    )
+    g = dataset_to_graph(mocker, product_id, dataset_url)
+
+    dataset = URIRef("http://data.europa.eu/88u/dataset/" + product_id)
+
+    dist = {}
+    for d in g.objects(dataset, DCAT.distribution):
+        url = g.value(d, DCAT.accessURL).toPython()
+        assert url
+        dist[url] = d
+
+    eeafigure_url = (
+        "https://www.eea.europa.eu/data-and-maps/figures/"
+        "eunis-habitat-types-per-biogeographic-region"
+    )
+    dist_eeafigure = dist[eeafigure_url]
+    assert g.value(dist_eeafigure, DCTERMS.title) == Literal(
+        "EUNIS habitat types per biogeographic region", lang="en"
+    )
+    assert g.value(dist_eeafigure, DCTERMS["format"]) == EU_FILE_TYPE.HTML
+    assert (
+            g.value(dist_eeafigure, DCTERMS.type) == EU_DISTRIBUTION_TYPE.VISUALIZATION
+    )
+    assert g.value(dist_eeafigure, DCTERMS.license) == EU_LICENSE.CC_BY_4_0
+    assert g.value(dist_eeafigure, ADMS.status) == EU_STATUS.COMPLETED
+    assert g.value(dist_eeafigure, DCAT.accessURL) == URIRef(eeafigure_url)
+
+
+def test_query_retrieve_forward_daviz(mocker):
+    product_id = "DAT-21-en"
+    dataset_url = (
+        "http://www.eea.europa.eu/data-and-maps/data/"
+        "european-union-emissions-trading-scheme-13"
+    )
+    g = dataset_to_graph(mocker, product_id, dataset_url)
+
+    dataset = URIRef("http://data.europa.eu/88u/dataset/" + product_id)
+
+    dist = {}
+    for d in g.objects(dataset, DCAT.distribution):
+        url = g.value(d, DCAT.accessURL).toPython()
+        assert url
+        dist[url] = d
+
+    daviz_url = (
+        "https://www.eea.europa.eu/data-and-maps/daviz/"
+        "eu-ets-emissions-by-activity-type"
+    )
+    dist_daviz = dist[daviz_url]
+    assert g.value(dist_daviz, DCTERMS.title) == Literal(
+        "EU ETS emissions by activity type", lang="en"
+    )
+    assert g.value(dist_daviz, DCTERMS["format"]) == EU_FILE_TYPE.HTML
+    assert (
+            g.value(dist_daviz, DCTERMS.type) == EU_DISTRIBUTION_TYPE.VISUALIZATION
+    )
+    assert g.value(dist_daviz, DCTERMS.license) == EU_LICENSE.CC_BY_4_0
+    assert g.value(dist_daviz, ADMS.status) == EU_STATUS.COMPLETED
+    assert g.value(dist_daviz, DCAT.accessURL) == URIRef(daviz_url)
+
+
+def test_query_retrieve_forward_gis_application(mocker):
+    """
+        TODO: At the moment there are only GIS Applications visualisations, all of
+        them being expired. The SPARQL queries check for visualisations with no
+        expiration dates. When a relevant example will exist, a test should be implemented.
+
+        The query that displays all the GIS Application visualisations alongside their expirations is:
+        PREFIX a: <http://www.eea.europa.eu/portal_types/Data#>
+        PREFIX gis: <http://www.eea.europa.eu/portal_types/GIS%20Application#>
+        PREFIX dct: <http://purl.org/dc/terms/>
+
+        SELECT ?dataset ?gis ?related_item_expires
+        WHERE {
+            ?dataset a a:Data ;
+                a:relatedItems ?gis.
+            ?gis a gis:GISApplication;
+                   dct:expires ?related_item_expires .
+        }
+        LIMIT 50
+    """
+
+
+def test_query_retrieve_backward_infographic(mocker):
+    product_id = "DAT-150-en"
+    dataset_url = (
+        "http://www.eea.europa.eu/data-and-maps/data/"
+        "air-pollutant-concentrations-at-station"
+    )
+    g = dataset_to_graph(mocker, product_id, dataset_url)
+
+    dataset = URIRef("http://data.europa.eu/88u/dataset/" + product_id)
+
+    dist = {}
+    for d in g.objects(dataset, DCAT.distribution):
+        url = g.value(d, DCAT.accessURL).toPython()
+        assert url
+        dist[url] = d
+
+    backward_infographic_url = (
+        "https://www.eea.europa.eu/media/infographics/"
+        "many-europeans-are-exposed-to-2"
+    )
+    dist_infograhic = dist[backward_infographic_url]
+    assert g.value(dist_infograhic, DCTERMS.title) == Literal(
+        "Many Europeans are exposed to harmful levels of air pollution", lang="en"
+    )
+    assert g.value(dist_infograhic, DCTERMS["format"]) == EU_FILE_TYPE.HTML
+    assert (
+            g.value(dist_infograhic, DCTERMS.type) == EU_DISTRIBUTION_TYPE.VISUALIZATION
+    )
+    assert g.value(dist_infograhic, DCTERMS.license) == EU_LICENSE.CC_BY_4_0
+    assert g.value(dist_infograhic, ADMS.status) == EU_STATUS.COMPLETED
+    assert g.value(dist_infograhic, DCAT.accessURL) == URIRef(backward_infographic_url)
+
+
+def test_query_retrieve_backward_eea_figure(mocker):
+    product_id = "DAT-150-en"
+    dataset_url = (
+        "http://www.eea.europa.eu/data-and-maps/data/"
+        "air-pollutant-concentrations-at-station"
+    )
+    g = dataset_to_graph(mocker, product_id, dataset_url)
+
+    dataset = URIRef("http://data.europa.eu/88u/dataset/" + product_id)
+
+    dist = {}
+    for d in g.objects(dataset, DCAT.distribution):
+        url = g.value(d, DCAT.accessURL).toPython()
+        assert url
+        dist[url] = d
+
+    backward_eea_figure_url = (
+        "https://www.eea.europa.eu/data-and-maps/figures/"
+        "urban-population-resident-in-areas-pollutant-limit-target"
+    )
+    dist_eea_figure = dist[backward_eea_figure_url]
+    assert g.value(dist_eea_figure, DCTERMS.title) == Literal(
+        "Percentage of urban population resident in areas where pollutant concentrations "
+        "are higher than selected limit/target values, 2000-2012 (EU-28)", lang="en"
+    )
+    assert g.value(dist_eea_figure, DCTERMS["format"]) == EU_FILE_TYPE.HTML
+    assert (
+            g.value(dist_eea_figure, DCTERMS.type) == EU_DISTRIBUTION_TYPE.VISUALIZATION
+    )
+    assert g.value(dist_eea_figure, DCTERMS.license) == EU_LICENSE.CC_BY_4_0
+    assert g.value(dist_eea_figure, ADMS.status) == EU_STATUS.COMPLETED
+    assert g.value(dist_eea_figure, DCAT.accessURL) == URIRef(backward_eea_figure_url)
+
+
+def test_query_retrieve_backward_dashboard(mocker):
+    product_id = "DAT-176-en"
+    dataset_url = (
+        "http://www.eea.europa.eu/data-and-maps/data/"
+        "fuel-quality-directive-1"
+    )
+    g = dataset_to_graph(mocker, product_id, dataset_url)
+
+    dataset = URIRef("http://data.europa.eu/88u/dataset/" + product_id)
+
+    dist = {}
+    for d in g.objects(dataset, DCAT.distribution):
+        url = g.value(d, DCAT.accessURL).toPython()
+        assert url
+        dist[url] = d
+
+    backward_dashboard_url = (
+        "https://www.eea.europa.eu/data-and-maps/dashboards/"
+        "fuel-quality-article-8"
+    )
+    print(dist.keys())
+    dist_dashboard = dist[backward_dashboard_url]
+    assert g.value(dist_dashboard, DCTERMS.title) == Literal(
+        "Petrol and diesel fuels sold for road transport", lang="en"
+    )
+    assert g.value(dist_dashboard, DCTERMS["format"]) == EU_FILE_TYPE.HTML
+    assert (
+            g.value(dist_dashboard, DCTERMS.type) == EU_DISTRIBUTION_TYPE.VISUALIZATION
+    )
+    assert g.value(dist_dashboard, DCTERMS.license) == EU_LICENSE.CC_BY_4_0
+    assert g.value(dist_dashboard, ADMS.status) == EU_STATUS.COMPLETED
+    assert g.value(dist_dashboard, DCAT.accessURL) == URIRef(backward_dashboard_url)

--- a/app/tests/test_odp_related_items.py
+++ b/app/tests/test_odp_related_items.py
@@ -9,15 +9,11 @@ from rdflib.namespace import DCTERMS
 import ckanclient
 from sdsclient import (
     DCAT,
-    VCARD,
     ADMS,
-    SCHEMA,
     EU_FILE_TYPE,
     EU_DISTRIBUTION_TYPE,
     EU_LICENSE,
     EU_STATUS,
-    EU_COUNTRY,
-    EUROVOC,
 )
 
 from .conftest import mock_sds
@@ -107,7 +103,7 @@ def test_query_retrieve_forward_daviz(mocker):
 
 def test_query_retrieve_forward_gis_application(mocker):
     """
-        TODO: At the moment there are only GIS Applications visualisations, all of
+        TODO: At the moment there are only two GIS Applications visualisations, both of
         them being expired. The SPARQL queries check for visualisations with no
         expiration dates. When a relevant example will exist, a test should be implemented.
 


### PR DESCRIPTION
```
PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
PREFIX cr: <http://cr.eionet.europa.eu/ontologies/contreg.rdf#>
PREFIX a: <http://www.eea.europa.eu/portal_types/Data#>
PREFIX dcat: <http://www.w3.org/ns/dcat#>


SELECT DISTINCT ?type
WHERE {
   ?dataset a dcat:Dataset;
            a:relatedItems ?item.
   ?item rdf:type ?type.
} LIMIT 50
```
Using the above query, I identified the following related item types:
> http://rdfdata.eionet.europa.eu/amp/ontology/Output
> http://www.eea.europa.eu/portal_types/DavizVisualization#DavizVisualization
> http://www.eea.europa.eu/portal_types/Report#Report
> http://www.eea.europa.eu/portal_types/Data#Data
> http://www.w3.org/ns/dcat#Dataset
> http://www.eea.europa.eu/portal_types/Document#Document
> http://www.eea.europa.eu/portal_types/GIS%20Application#GISApplication
> http://www.eea.europa.eu/portal_types/EEAFigureFile#EEAFigureFile
> http://www.eea.europa.eu/portal_types/Promotion#Promotion
> http://www.eea.europa.eu/portal_types/File#File
> http://www.eea.europa.eu/portal_types/EEAFigure#EEAFigure)

The ticket mentions:
>     Dashboard (Tableau)
>     Interactive Map (GIS Application)
>     EEA Figure
>     Infographic

I don't really see a mapping for Infographic and Dashboard(Tableau). Also, the publish still returns an error 500 and I'm quite stuck in testing the workflow for now.
