### PR TITLE
No need to truncate resources any more.

### DIFF
--- a/app/remap.py
+++ b/app/remap.py
@@ -177,7 +177,6 @@ class RemapDatasets:
         data["uri"] = ckan_uri
 
         data["status"] = str(EU_STATUS.DEPRECATED)
-        data["resources"][100:] = []
         for r in data["resources"]:
             r["status"] = str(EU_STATUS.DEPRECATED)
         data["title"] = "[DEPRECATED] " + data["title"]


### PR DESCRIPTION
The truncation was done for the Urban Atlas dataset, which had more than 300 downloads, and was getting rejected by the ODP. The issue has been fixed upstream; tested on the acceptance server.

http://www.eea.europa.eu/data-and-maps/data/urban-atlas
http://data.europa.eu/88u/dataset/data_urban-atlas